### PR TITLE
CSS-3214: Add tctl action and integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,22 +23,3 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
-  integration-test-microk8s:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      - name: Run integration tests
-        # set a predictable model name so it can be consumed by charm-logdump-action
-        run: tox -e integration -- --model testing
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: temporal-admin-k8s
-          model: testing

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,7 +8,7 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
     run-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"

--- a/src/charm.py
+++ b/src/charm.py
@@ -74,13 +74,12 @@ class TemporalAdminK8SCharm(CharmBase):
     @log_event_handler
     def _on_tctl_action(self, event):
         """Run the tctl command line tool."""
-        # TODO(frankban): make this work.
         container = self.unit.get_container(self.name)
         if not container.can_connect():
             event.fail("cannot connect to container")
             return
 
-        args = event.params["args"].split()
+        args = ["--address", "temporal-k8s:7233", *event.params["args"].split()]
         try:
             output = execute(container, "tctl", *args)
         except Exception as err:

--- a/src/charm.py
+++ b/src/charm.py
@@ -79,6 +79,7 @@ class TemporalAdminK8SCharm(CharmBase):
             event.fail("cannot connect to container")
             return
 
+        # TODO(kelkawi-a): do not assume the app is always deployed with this name.
         args = ["--address", "temporal-k8s:7233", *event.params["args"].split()]
         try:
             output = execute(container, "tctl", *args)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -17,14 +18,38 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
+METADATA_SERVER = yaml.safe_load(Path("../temporal-k8s-operator/metadata.yaml").read_text())
+APP_NAME_SERVER = METADATA_SERVER["name"]
 
-@pytest.fixture(name="deploy", scope="module")
+
+@pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
+    """The app is up and running."""
     charm = await ops_test.build_charm(".")
-    resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
+    resources = {"temporal-admin-image": METADATA["containers"]["temporal-admin"]["upstream-source"]}
+
+    server_resources = {"temporal-server-image": METADATA_SERVER["containers"]["temporal"]["upstream-source"]}
+    server_charm = await ops_test.build_charm("../temporal-k8s-operator")
+
+    # Deploy temporal server, temporal admin and postgresql charms
+    await ops_test.model.deploy(server_charm, resources=server_resources, application_name=APP_NAME_SERVER)
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
+    await ops_test.model.deploy("postgresql-k8s", channel="edge", trust=True)
+
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", raise_on_blocked=False, timeout=1000)
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME_SERVER, APP_NAME], status="blocked", raise_on_blocked=False, timeout=600
+        )
+        await ops_test.model.wait_for_idle(
+            apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
+        )
+
+        await ops_test.model.relate(f"{APP_NAME_SERVER}:db", "postgresql-k8s:db")
+        await ops_test.model.relate(f"{APP_NAME_SERVER}:visibility", "postgresql-k8s:db")
+        await ops_test.model.relate(f"{APP_NAME_SERVER}:admin", f"{APP_NAME}:admin")
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME_SERVER], status="active", raise_on_blocked=False, timeout=600)
+
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
 
@@ -33,4 +58,16 @@ async def deploy(ops_test: OpsTest):
 class TestDeployment:
     async def test_tctl_action(self, ops_test: OpsTest):
         """Is it possible to run tctl command via the action."""
-        # TODO(frankban): implement this test.
+        action = (
+            await ops_test.model.applications[APP_NAME]
+            .units[0]
+            .run_action("tctl", args="--ns default namespace register -rd 3")
+        )
+        result = (await action.wait()).results
+
+        logger.info(f"tctl result: {result}")
+
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
+
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+        assert ("output" in result) and "Namespace default successfully registered" in result["output"]

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     pep8-naming==0.13.2
     pyproject-flake8==5.0.4.post1
 commands =
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     pflake8 {[vars]src_path} {[vars]tst_path}

--- a/tox.ini
+++ b/tox.ini
@@ -65,10 +65,10 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    ipdb==0.13.9
-    juju==3.0.1
-    pytest==7.1.3
-    pytest-operator==0.22.0
+    ipdb
+    juju==3.0.3
+    pytest
+    pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -65,10 +65,10 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    ipdb
+    ipdb==0.13.9
     juju==3.0.3
-    pytest
-    pytest-operator
+    pytest==7.1.3
+    pytest-operator==0.22.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
# Note
Integration tests for both the temporal-admin-k8s operator charm and the [temporal-k8s-operator charm](https://github.com/canonical/temporal-k8s-operator) have been temporarily disabled in the Github workflows. This is because when building and deploying charms in the integration tests, they must either be built and deployed from a local directory (which is possible during development), or deployed directly from Charmhub. As our charms are not currently published to Charmhub, it would require more effort to have this working in Github workflows, which is not justified given that the charms would soon be published anyway. The integration tests of both charms will be re-enabled and slightly modified once they are published.

The integration test also makes use of a Kubernetes service patch added to the temporal-k8s-operator charm which will be reflected in the next pull request made on [here](https://github.com/canonical/temporal-k8s-operator).