### PR TITLE
CSS-3634: Upgrade resource to v1.21.5

### DIFF
--- a/.github/workflows/promote_charm.yaml
+++ b/.github/workflows/promote_charm.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   promote-charm:
-    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/promote_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,5 +5,5 @@ on:
 
 jobs:
   unit-tests:
-    uses: canonical/operator-workflows/.github/workflows/test.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     secrets: inherit

--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   publish-to-edge:
-    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
+    uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@8892eb826818585b397295e40276ddd0c5d3d459
     secrets: inherit
     with:
       integration-test-provider: microk8s

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -35,7 +35,7 @@ containers:
   temporal-admin:
     resource: temporal-admin-image
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/admin-tools:1.18.0
+    upstream-source: temporalio/admin-tools:1.21.5
 
 resources:
   temporal-admin-image:


### PR DESCRIPTION
As part of upgrading the [Temporal server charm](https://github.com/canonical/temporal-k8s-operator) to v1.21.5, this PR upgrades the version of the admin-tools to also use the v1.21.5 image.