### PR TITLE
Update PostgreSQL schema version

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,38 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Canonical Ltd.
+    copyright-year: 2023
+    content: |
+      Copyright [year] [owner]
+      See LICENSE file for licensing details.
+  paths:
+    - '**'
+  paths-ignore:
+    - '.github/**'
+    - '**/.gitkeep'
+    - '**/*.cfg'
+    - '**/*.conf'
+    - '**/*.j2'
+    - '**/*.json'
+    - '**/*.md'
+    - '**/*.rule'
+    - '**/*.tmpl'
+    - '**/*.txt'
+    - '**/*.jinja'
+    - '.codespellignore'
+    - '.dockerignore'
+    - '.flake8'
+    - '.jujuignore'
+    - '.gitignore'
+    - '.licenserc.yaml'
+    - '.trivyignore'
+    - '.woke.yaml'
+    - '.woke.yml'
+    - 'CODEOWNERS'
+    - 'icon.svg'
+    - 'LICENSE'
+    - 'trivy.yaml'
+    - 'lib/**'
+    - 'templates/*'
+  comment: on-failure

--- a/src/charm.py
+++ b/src/charm.py
@@ -143,8 +143,8 @@ class TemporalAdminK8SCharm(CharmBase):
             return
 
         schema_dirs = {
-            "db": "/etc/temporal/schema/postgresql/v96/temporal/versioned",
-            "visibility": "/etc/temporal/schema/postgresql/v96/visibility/versioned",
+            "db": "/etc/temporal/schema/postgresql/v12/temporal/versioned",
+            "visibility": "/etc/temporal/schema/postgresql/v12/visibility/versioned",
         }
         for key, database_connection in self._state.database_connections.items():
             logger.info(f"initializing {key} schema")

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -96,7 +96,8 @@ deps =
     ipdb==0.13.9
     juju==3.1.0.1
     pytest==7.1.3
-    pytest-operator==0.22.0
+    pytest-operator==0.31.1
+    pytest-asyncio==0.21
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --destructive-mode


### PR DESCRIPTION
In line with using Temporal server v1.21.5, this PR updates the version of the PostgreSQL schema used as highlighted in the v1.20.0 [release notes](https://github.com/temporalio/temporal/releases/tag/v1.20.0). This will enable the update of the Temporal server config to enable [advanced visibility](https://docs.temporal.io/visibility#advanced-visibility).