### PR TITLE
Change temporal-k8s connection address

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,8 @@ options:
     default: info
     description: Temporal server logging level.
     type: string
+  server-name:
+    description: |
+        The name with which the Temporal server frontend service is deployed.
+    default: "temporal-k8s"
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class TemporalAdminK8SCharm(CharmBase):
             return
 
         # TODO(kelkawi-a): do not assume the app is always deployed with this name.
-        args = ["--address", "temporal-k8s:7233", *event.params["args"].split()]
+        args = ["--address", "temporal-k8s:7236", *event.params["args"].split()]
         try:
             output = execute(container, "tctl", *args)
         except Exception as err:

--- a/src/charm.py
+++ b/src/charm.py
@@ -114,8 +114,8 @@ class TemporalAdminK8SCharm(CharmBase):
             event.fail("cannot connect to container")
             return
 
-        # TODO(kelkawi-a): do not assume the app is always deployed with this name.
-        args = ["--address", "temporal-k8s:7236", *event.params["args"].split()]
+        server_name = self.model.config["server-name"] or "temporal-k8s"
+        args = ["--address", f"{server_name}:7236", *event.params["args"].split()]
         try:
             output = execute(container, "tctl", *args)
         except Exception as err:

--- a/temporal_auth_model.json
+++ b/temporal_auth_model.json
@@ -1,0 +1,95 @@
+{
+    "type_definitions": [
+      {
+        "type": "user",
+        "relations": {},
+        "metadata": null
+      },
+      {
+        "type": "namespace",
+        "relations": {
+          "admin": {
+            "this": {}
+          },
+          "reader": {
+            "union": {
+              "child": [
+                {
+                  "this": {}
+                },
+                {
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "writer"
+                  }
+                }
+              ]
+            }
+          },
+          "writer": {
+            "union": {
+              "child": [
+                {
+                  "this": {}
+                },
+                {
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "admin"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "metadata": {
+          "relations": {
+            "admin": {
+              "directly_related_user_types": [
+                {
+                  "type": "group",
+                  "relation": "member"
+                }
+              ]
+            },
+            "reader": {
+              "directly_related_user_types": [
+                {
+                  "type": "group",
+                  "relation": "member"
+                }
+              ]
+            },
+            "writer": {
+              "directly_related_user_types": [
+                {
+                  "type": "group",
+                  "relation": "member"
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "type": "group",
+        "relations": {
+          "member": {
+            "this": {}
+          }
+        },
+        "metadata": {
+          "relations": {
+            "member": {
+              "directly_related_user_types": [
+                {
+                  "type": "user"
+                }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "schema_version": "1.1"
+  }

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Temporal admin charm integration test helpers."""
+
+import logging
+from pathlib import Path
+
+import yaml
+from pytest_operator.plugin import OpsTest
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+APP_NAME = METADATA["name"]
+SERVER_APP_NAME = "temporal-k8s"
+
+logger = logging.getLogger(__name__)
+
+
+async def run_tctl_action(ops_test: OpsTest, namespace):
+    """Run tctl action from the admin charm to create a namespace.
+
+    Args:
+        ops_test: PyTest object.
+        namespace: Namespace to create in Temporal server.
+    """
+    action = (
+        await ops_test.model.applications[APP_NAME]
+        .units[0]
+        .run_action("tctl", args=f"--ns {namespace} namespace register -rd 3")
+    )
+    result = (await action.wait()).results
+
+    logger.info(f"tctl result: {result}")
+
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
+
+    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
+    assert ("output" in result) and f"Namespace {namespace} successfully registered" in result["output"]

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -30,7 +30,7 @@ async def deploy(ops_test: OpsTest):
     # Deploy temporal server, temporal admin and postgresql charms
     await ops_test.model.deploy("temporal-k8s", channel="edge")
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
-    await ops_test.model.deploy("postgresql-k8s", channel="14", trust=True)
+    await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
@@ -43,15 +43,6 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:db", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
-
-        await ops_test.juju(
-            "exec",
-            "--unit",
-            "temporal-k8s/0",
-            "--",
-            "open-port",
-            "7233",
-        )
 
         await ops_test.model.wait_for_idle(apps=["temporal-k8s"], status="active", raise_on_blocked=False, timeout=600)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,18 +7,17 @@
 
 """Temporal admin charm integration tests."""
 
+import json
 import logging
-from pathlib import Path
+import time
 
 import pytest
 import pytest_asyncio
-import yaml
+from helpers import APP_NAME, METADATA, SERVER_APP_NAME, run_tctl_action
+from juju.action import Action
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-APP_NAME = METADATA["name"]
 
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
@@ -28,13 +27,13 @@ async def deploy(ops_test: OpsTest):
     resources = {"temporal-admin-image": METADATA["containers"]["temporal-admin"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms
-    await ops_test.model.deploy("temporal-k8s", channel="edge")
+    await ops_test.model.deploy(SERVER_APP_NAME, channel="edge")
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=["temporal-k8s", APP_NAME], status="blocked", raise_on_blocked=False, timeout=600
+            apps=[SERVER_APP_NAME, APP_NAME], status="blocked", raise_on_blocked=False, timeout=600
         )
         await ops_test.model.wait_for_idle(
             apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
@@ -44,7 +43,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
 
-        await ops_test.model.wait_for_idle(apps=["temporal-k8s"], status="active", raise_on_blocked=False, timeout=600)
+        await ops_test.model.wait_for_idle(apps=[SERVER_APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
 
@@ -56,16 +55,83 @@ class TestDeployment:
 
     async def test_tctl_action(self, ops_test: OpsTest):
         """Is it possible to run tctl command via the action."""
-        action = (
-            await ops_test.model.applications[APP_NAME]
-            .units[0]
-            .run_action("tctl", args="--ns default namespace register -rd 3")
+        await run_tctl_action(ops_test, namespace="default")
+
+    async def test_openfga_relation(self, ops_test: OpsTest):
+        """Add OpenFGA relation and authorization model."""
+        await ops_test.model.applications[SERVER_APP_NAME].set_config({"auth-enabled": "true"})
+        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
+        await ops_test.model.wait_for_idle(
+            apps=[SERVER_APP_NAME, "openfga-k8s"],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=1200,
         )
-        result = (await action.wait()).results
 
-        logger.info(f"tctl result: {result}")
+        logger.info("adding openfga postgresql relation")
+        await ops_test.model.integrate("openfga-k8s:database", "postgresql-k8s:database")
 
-        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
+        await ops_test.model.wait_for_idle(
+            apps=["openfga-k8s"],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=1200,
+        )
 
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-        assert ("output" in result) and "Namespace default successfully registered" in result["output"]
+        openfga_unit = ops_test.model.applications["openfga-k8s"].units[0]
+        for i in range(10):
+            action: Action = await openfga_unit.run_action("schema-upgrade")
+            result = await action.wait()
+            logger.info(f"attempt {i} -> action result {result.status} {result.results}")
+            if result.results == {"result": "done", "return-code": 0}:
+                break
+            time.sleep(2)
+
+        await ops_test.model.wait_for_idle(
+            apps=["openfga-k8s"],
+            status="active",
+            raise_on_blocked=True,
+            timeout=1200,
+        )
+
+        logger.info("adding openfga relation")
+        await ops_test.model.integrate(SERVER_APP_NAME, "openfga-k8s")
+
+        await ops_test.model.wait_for_idle(
+            apps=[SERVER_APP_NAME],
+            status="blocked",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+
+        logger.info("running the create authorization model action")
+        temporal_unit = ops_test.model.applications[SERVER_APP_NAME].units[0]
+        with open("./temporal_auth_model.json", "r", encoding="utf-8") as model_file:
+            model_data = model_file.read()
+
+            # Remove whitespace and newlines from JSON object
+            json_text = "".join(model_data.split())
+            data = json.loads(json_text)
+            model_data = json.dumps(data, separators=(",", ":"))
+
+            for i in range(10):
+                action = await temporal_unit.run_action(
+                    "create-authorization-model",
+                    model=model_data,
+                )
+                result = await action.wait()
+                logger.info(f"attempt {i} -> action result {result.status} {result.results}")
+                if result.status == "completed" and result.results == {"return-code": 0}:
+                    break
+                time.sleep(2)
+
+        await ops_test.model.wait_for_idle(
+            apps=[SERVER_APP_NAME],
+            status="active",
+            raise_on_blocked=True,
+            timeout=300,
+        )
+
+        assert ops_test.model.applications[APP_NAME].status == "active"
+
+        await run_tctl_action(ops_test, namespace="integrations")


### PR DESCRIPTION
The purpose of this PR is explained in the Temporal server [PR](https://github.com/canonical/temporal-k8s-operator/pull/27). The integration tests are not expected to pass until the Temporal server charm is merged.