### PR TITLE
Add peer relation and admin relation broken hook

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,6 +26,10 @@ assumes:
   - juju >= 3.1
   - k8s-api
 
+peers:
+  peer:
+    interface: temporal-admin
+
 provides:
   admin:
     interface: temporal

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,66 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for handling charm state."""
+
+import json
+
+
+class State:
+    """A magic state that uses a relation as the data store.
+
+    The get_relation callable is used to retrieve the relation.
+    As relation data values must be strings, all values are JSON encoded.
+    """
+
+    def __init__(self, app, get_relation):
+        """Construct.
+
+        Args:
+            app: workload application
+            get_relation: get peer relation method
+        """
+        # Use __dict__ to avoid calling __setattr__ and subsequent infinite recursion.
+        self.__dict__["_app"] = app
+        self.__dict__["_get_relation"] = get_relation
+
+    def __setattr__(self, name, value):
+        """Set a value in the store with the given name.
+
+        Args:
+            name: name of value to set in store.
+            value: value to set in store.
+        """
+        v = json.dumps(value)
+        self._get_relation().data[self._app].update({name: v})
+
+    def __getattr__(self, name):
+        """Get from the store the value with the given name, or None.
+
+        Args:
+            name: name of value to get from store.
+
+        Returns:
+            value from store with given name.
+        """
+        v = self._get_relation().data[self._app].get(name, "null")
+        return json.loads(v)
+
+    def __delattr__(self, name):
+        """Delete the value with the given name from the store, if it exists.
+
+        Args:
+            name: name of value to delete from store.
+
+        Returns:
+            deleted value from store.
+        """
+        return self._get_relation().data[self._app].pop(name, None)
+
+    def is_ready(self):
+        """Report whether the relation is ready to be used.
+
+        Returns:
+            A boolean representing whether the relation is ready to be used or not.
+        """
+        return bool(self._get_relation())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,6 +15,7 @@ from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import TemporalAdminK8SCharm
+from state import State
 
 
 class TestCharm(TestCase):
@@ -44,6 +45,9 @@ class TestCharm(TestCase):
         """The charm is blocked without a temporal:admin relation."""
         harness = self.harness
 
+        # Simulate peer relation readiness.
+        harness.add_relation("peer", "temporal-admin")
+
         # Simulate pebble readiness.
         container = harness.model.unit.get_container("temporal-admin")
         harness.charm.on.temporal_admin_pebble_ready.emit(container)
@@ -58,6 +62,9 @@ class TestCharm(TestCase):
         """The state is blocked when creating schemas but losing the admin relation."""
         harness = self.harness
 
+        # Simulate peer relation readiness.
+        harness.add_relation("peer", "temporal-admin")
+
         with mock.patch("charm.execute"):
             simulate_lifecycle(harness)
 
@@ -67,6 +74,9 @@ class TestCharm(TestCase):
     def test_ready(self):
         """The pebble plan is correctly generated when the charm is ready."""
         harness = self.harness
+
+        # Simulate peer relation readiness.
+        harness.add_relation("peer", "temporal-admin")
 
         # Add the temporal relation.
         harness.add_relation("admin", "temporal")
@@ -138,3 +148,61 @@ def simulate_lifecycle(harness):
     )()
     event = type("Event", (), {"app": app, "relation": relation})()
     harness.charm._on_admin_relation_changed(event)
+
+
+class TestState(TestCase):
+    """Unit tests for state.
+
+    Attrs:
+        maxDiff: Specifies max difference shown by failed tests.
+    """
+
+    maxDiff = None
+
+    def test_get(self):
+        """It is possible to retrieve attributes from the state."""
+        state = make_state({"foo": json.dumps("bar")})
+        self.assertEqual(state.foo, "bar")
+        self.assertIsNone(state.bad)
+
+    def test_set(self):
+        """It is possible to set attributes in the state."""
+        data = {"foo": json.dumps("bar")}
+        state = make_state(data)
+        state.foo = 42
+        state.list = [1, 2, 3]
+        self.assertEqual(state.foo, 42)
+        self.assertEqual(state.list, [1, 2, 3])
+        self.assertEqual(data, {"foo": "42", "list": "[1, 2, 3]"})
+
+    def test_del(self):
+        """It is possible to unset attributes in the state."""
+        data = {"foo": json.dumps("bar"), "answer": json.dumps(42)}
+        state = make_state(data)
+        del state.foo
+        self.assertIsNone(state.foo)
+        self.assertEqual(data, {"answer": "42"})
+        # Deleting a name that is not set does not error.
+        del state.foo
+
+    def test_is_ready(self):
+        """The state is not ready when it is not possible to get relations."""
+        state = make_state({})
+        self.assertTrue(state.is_ready())
+
+        state = State("myapp", lambda: None)
+        self.assertFalse(state.is_ready())
+
+
+def make_state(data):
+    """Create state object.
+
+    Args:
+        data: Data to be included in state.
+
+    Returns:
+        State object with data.
+    """
+    app = "myapp"
+    rel = type("Rel", (), {"data": {app: data}})()
+    return State(app, lambda: rel)

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
     isort --check-only --diff {[vars]src_path} {[vars]tst_path}
     black --check --diff {[vars]src_path} {[vars]tst_path}
     mypy {[vars]all_path} --ignore-missing-imports --install-types --non-interactive
-    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0301
+    pylint {[vars]all_path} --disable=E0401,W1203,W0613,W0718,R0903,W1514,C0301,C0104
 
 [testenv:unit]
 description = Run tests


### PR DESCRIPTION
This PR does the following:

- changes the charm's state from `StoredState` to using peer relation state, which is the recommended state to use and conforms with the design of the rest of the Temporal charms.
- Adds an `on_admin_relation_broken` hook which sends the charm into a blocked state if the relation with the server charm is broken.