### PR TITLE
Refactor charm code

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,6 +17,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from state import State
 
 logger = logging.getLogger(__name__)
+WORKLOAD_VERSION = "1.21.5"
 
 
 def log_event_handler(method):
@@ -98,6 +99,10 @@ class TemporalAdminK8SCharm(CharmBase):
         Args:
             event: The event triggered when the relation changed.
         """
+        if not self._state.is_ready():
+            event.defer()
+            return
+
         self.unit.status = WaitingStatus(f"handling {event.relation.name} change")
         database_connections = event.relation.data[event.app].get("database_connections")
         self._state.database_connections = json.loads(database_connections) if database_connections else None
@@ -110,6 +115,10 @@ class TemporalAdminK8SCharm(CharmBase):
         Args:
             event: The event triggered when the relation was broken.
         """
+        if not self._state.is_ready():
+            event.defer()
+            return
+
         self._state.database_connections = None
         self._setup_db_schemas(event)
 
@@ -118,7 +127,7 @@ class TemporalAdminK8SCharm(CharmBase):
         """Run the tctl command line tool.
 
         Args:
-            event: The event triggered when the relation changed.
+            event: The event triggered when the action is triggered.
         """
         container = self.unit.get_container(self.name)
         if not container.can_connect():
@@ -144,6 +153,10 @@ class TemporalAdminK8SCharm(CharmBase):
         if not self.model.unit.is_leader():
             return
 
+        if not self._state.is_ready():
+            event.defer()
+            return
+
         container = self.unit.get_container(self.name)
         if not container.can_connect():
             event.defer()
@@ -159,44 +172,48 @@ class TemporalAdminK8SCharm(CharmBase):
         }
         for key, database_connection in self._state.database_connections.items():
             logger.info(f"initializing {key} schema")
-            execute(
-                container,
-                "temporal-sql-tool",
-                "--plugin",
-                "postgres",
-                "--endpoint",
-                database_connection["host"],
-                "--port",
-                database_connection["port"],
-                "--database",
-                database_connection["dbname"],
-                "--user",
-                database_connection["user"],
-                "--password",
-                database_connection["password"],
-                "setup-schema",
-                "-v",
-                "0.0",
-            )
-            execute(
-                container,
-                "temporal-sql-tool",
-                "--plugin",
-                "postgres",
-                "--endpoint",
-                database_connection["host"],
-                "--port",
-                database_connection["port"],
-                "--database",
-                database_connection["dbname"],
-                "--user",
-                database_connection["user"],
-                "--password",
-                database_connection["password"],
-                "update-schema",
-                "-d",
-                schema_dirs[key],
-            )
+            try:
+                execute(
+                    container,
+                    "temporal-sql-tool",
+                    "--plugin",
+                    "postgres",
+                    "--endpoint",
+                    database_connection["host"],
+                    "--port",
+                    database_connection["port"],
+                    "--database",
+                    database_connection["dbname"],
+                    "--user",
+                    database_connection["user"],
+                    "--password",
+                    database_connection["password"],
+                    "setup-schema",
+                    "-v",
+                    "0.0",
+                )
+                execute(
+                    container,
+                    "temporal-sql-tool",
+                    "--plugin",
+                    "postgres",
+                    "--endpoint",
+                    database_connection["host"],
+                    "--port",
+                    database_connection["port"],
+                    "--database",
+                    database_connection["dbname"],
+                    "--user",
+                    database_connection["user"],
+                    "--password",
+                    database_connection["password"],
+                    "update-schema",
+                    "-d",
+                    schema_dirs[key],
+                )
+            except Exception as e:
+                logger.error(f"Error setting up schema: {e}")
+                self.unit.status = BlockedStatus("error setting up schema. remove relation and try again.")
 
         admin_relations = self.model.relations["admin"]
         if not admin_relations:
@@ -210,6 +227,7 @@ class TemporalAdminK8SCharm(CharmBase):
             logger.debug(f"admin:temporal: notifying schema readiness on relation {relation.id}")
             relation.data[self.app].update({"schema_status": "ready"})
 
+        self.unit.set_workload_version(WORKLOAD_VERSION)
         self.unit.status = ActiveStatus()
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,6 +214,7 @@ class TemporalAdminK8SCharm(CharmBase):
             except Exception as e:
                 logger.error(f"Error setting up schema: {e}")
                 self.unit.status = BlockedStatus("error setting up schema. remove relation and try again.")
+                return
 
         admin_relations = self.model.relations["admin"]
         if not admin_relations:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,7 +14,6 @@ import time
 import pytest
 import pytest_asyncio
 from helpers import APP_NAME, METADATA, SERVER_APP_NAME, run_tctl_action
-from juju.action import Action
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -23,11 +22,12 @@ logger = logging.getLogger(__name__)
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
+    await ops_test.model.set_config({"update-status-hook-interval": "1m"})
     charm = await ops_test.build_charm(".")
     resources = {"temporal-admin-image": METADATA["containers"]["temporal-admin"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms
-    await ops_test.model.deploy(SERVER_APP_NAME, channel="edge")
+    await ops_test.model.deploy(SERVER_APP_NAME, channel="edge", config={"num-history-shards": 1})
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
 
@@ -60,7 +60,7 @@ class TestDeployment:
     async def test_openfga_relation(self, ops_test: OpsTest):
         """Add OpenFGA relation and authorization model."""
         await ops_test.model.applications[SERVER_APP_NAME].set_config({"auth-enabled": "true"})
-        await ops_test.model.deploy("openfga-k8s", channel="1.0/edge")
+        await ops_test.model.deploy("openfga-k8s", channel="latest/edge")
         await ops_test.model.wait_for_idle(
             apps=[SERVER_APP_NAME, "openfga-k8s"],
             status="blocked",
@@ -73,24 +73,8 @@ class TestDeployment:
 
         await ops_test.model.wait_for_idle(
             apps=["openfga-k8s"],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=1200,
-        )
-
-        openfga_unit = ops_test.model.applications["openfga-k8s"].units[0]
-        for i in range(10):
-            action: Action = await openfga_unit.run_action("schema-upgrade")
-            result = await action.wait()
-            logger.info(f"attempt {i} -> action result {result.status} {result.results}")
-            if result.results == {"result": "done", "return-code": 0}:
-                break
-            time.sleep(2)
-
-        await ops_test.model.wait_for_idle(
-            apps=["openfga-k8s"],
             status="active",
-            raise_on_blocked=True,
+            raise_on_blocked=False,
             timeout=1200,
         )
 


### PR DESCRIPTION
This PR refactors charm code as follows:
- Wraps any peer relation data access with a `self._state.is_ready()` check.
- Wraps the `exec()` in a try/except block to send the charm into a blocked state if the schema setup fails.
- Sets the workload container version.