### PR TITLE
Update to v1.23.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -39,7 +39,7 @@ containers:
   temporal-admin:
     resource: temporal-admin-image
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/admin-tools:1.21.5
+    upstream-source: temporalio/admin-tools:1.23.1
 
 resources:
   temporal-admin-image:

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,7 +17,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from state import State
 
 logger = logging.getLogger(__name__)
-WORKLOAD_VERSION = "1.21.5"
+WORKLOAD_VERSION = "1.23.1"
 
 
 def log_event_handler(method):


### PR DESCRIPTION
This PR updates the Temporal admin tools to the latest available version `v1.23.1`.