### PR TITLE
Fix publish charm workflow issue

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -38,10 +38,10 @@ provides:
 containers:
   temporal-admin:
     resource: temporal-admin-image
-    # Included for simplicity in integration tests.
-    upstream-source: temporalio/admin-tools:1.23.1
 
 resources:
   temporal-admin-image:
     type: oci-image
     description: OCI image for Temporal admin tools
+    # Included for simplicity in integration tests.
+    upstream-source: temporalio/admin-tools:1.23.1

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -30,7 +30,7 @@ async def deploy(ops_test: OpsTest):
     """The app is up and running."""
     await ops_test.model.set_config({"update-status-hook-interval": "1m"})
     charm = await ops_test.build_charm(".")
-    resources = {"temporal-admin-image": METADATA["containers"]["temporal-admin"]["upstream-source"]}
+    resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms
     await ops_test.model.deploy(SERVER_APP_NAME, channel="edge", config={"num-history-shards": 1})


### PR DESCRIPTION
This PR addresses the issue with [this workflow](https://github.com/canonical/temporal-admin-k8s-operator/actions/runs/9861042487) failing as it expects to find the upstream resource in a specific place under `metadata.yaml` so as not to attempt to download the non-existent OCI image from the integration test run.