### PR TITLE
Add tls_enabled flag in admin relation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,5 +10,5 @@ jobs:
     with:
       channel: 1.28-strict/stable
       modules: '["test_charm.py"]'
-      juju-channel: 3.1/stable
+      juju-channel: 3.4/stable
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,7 +23,7 @@ tags:
   - admin
 issues: https://github.com/canonical/temporal-admin-k8s-operator/issues
 assumes:
-  - juju >= 3.1
+  - juju >= 3.4
   - k8s-api
 
 peers:
@@ -44,4 +44,4 @@ resources:
     type: oci-image
     description: OCI image for Temporal admin tools
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/admin-tools:1.23.1
+    upstream-source: temporalio/admin-tools:1.23.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ commands =
 description = Run integration tests
 deps =
     ipdb==0.13.9
-    juju==3.1.0.1
+    juju==3.5.2.0
     pytest==7.1.3
     pytest-operator==0.31.1
     pytest-asyncio==0.21


### PR DESCRIPTION
To enable TLS on the database, the command for setting up and updating the schemas needs to be amended by adding some flags. This PR adds these flags conditionally, based on the `tls_enabled` flag it will receive through the charm relation with the `temporal-k8s` charm. Another PR will follow on the `temporal-k8s-operator` repo which will implement this change.