### PR TITLE
Run integration tests against 3.6/stable juju

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,5 +10,5 @@ jobs:
     with:
       channel: 1.28-strict/stable
       modules: '["test_charm.py"]'
-      juju-channel: 3.4/stable
+      juju-channel: 3.6/stable
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"


### PR DESCRIPTION
We would like to start testing all temporal charms against the LTS juju version (3.6/stable)