### PR TITLE
ci: publish to 1.23 from the default branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,4 @@ jobs:
       release-channel: "1.23/edge"
       charm-path: "."
       charmcraft-channel: "3.x/candidate"
+      runners: '["ubuntu-latest"]'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,6 @@ jobs:
       contents: write
     secrets: inherit
     with:
-      release-channel: "latest/edge"
+      release-channel: "1.23/edge"
       charm-path: "."
       charmcraft-channel: "3.x/candidate"


### PR DESCRIPTION


## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

This commit forces the release workflow to publish to the 1.23/edge track from the default branch.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
