### PR TITLE
[WF-79] Update to 1.23 server rock

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,6 +10,6 @@ jobs:
     secrets: inherit
     with:
       channel: 1.28-strict/stable
-      modules: '["test_charm.py"]'
+      modules: '["test_charm.py", "test_refresh.py"]'
       juju-channel: 3.6/stable
       microk8s-addons: "dns ingress rbac storage metallb:10.15.119.2-10.15.119.4 registry"

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,13 +1,14 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-tctl:
-  description: Run the tctl command.
+cli:
+  description: Run the temporal cli command.
   params:
     args:
       type: string
       description: The command line arguments.
-  required: [args]
+  required:
+  - args
 
 setup-schema:
   description: Set up the database schema.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,4 +44,4 @@ resources:
     type: oci-image
     description: OCI image for Temporal admin tools
     # Included for simplicity in integration tests.
-    upstream-source: temporalio/admin-tools:1.23.1.0
+    upstream-source: ubuntu/temporal-server:1.23.1-24.04_edge@sha256:d429a4fa2ded4639a17fe3992f51648acb7e37b940c06132901c88422d8cffb2

--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,7 @@ class TemporalAdminK8SCharm(CharmBase):
         self.framework.observe(self.on.admin_relation_broken, self._on_admin_relation_broken)
 
         # Handle action
-        self.framework.observe(self.on.tctl_action, self._on_tctl_action)
+        self.framework.observe(self.on.cli_action, self._on_cli_action)
         self.framework.observe(self.on.setup_schema_action, self._on_setup_schema_action)
 
     @log_event_handler
@@ -135,8 +135,8 @@ class TemporalAdminK8SCharm(CharmBase):
         self._setup_db_schemas(event)
 
     @log_event_handler
-    def _on_tctl_action(self, event):
-        """Run the tctl command line tool.
+    def _on_cli_action(self, event):
+        """Run the temporal command line tool.
 
         Args:
             event: The event triggered when the action is triggered.
@@ -149,7 +149,7 @@ class TemporalAdminK8SCharm(CharmBase):
         server_name = self.model.config["server-name"] or "temporal-k8s"
         args = ["--address", f"{server_name}:7236", *event.params["args"].split()]
         try:
-            output = execute(container, "tctl", *args)
+            output = execute(container, "temporal", *args)
         except Exception as err:
             event.fail(f"command failed: {err}")
             return

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,7 @@ def admin_tools_latest(juju: jubilant.Juju):
 
     juju.deploy(
         charm="postgresql-k8s",
+        app="postgresql-k8s",
         channel="14/stable",
         trust=True,
         base="ubuntu@22.04",
@@ -42,6 +43,7 @@ def admin_tools_latest(juju: jubilant.Juju):
 
     juju.deploy(
         charm="temporal-k8s",
+        app="temporal-k8s",
         channel="1.23/edge",
         config={
             "num-history-shards": 1,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for jubilant tests."""
+
+import pathlib
+
+import jubilant
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="module")
+def juju(request: pytest.FixtureRequest):
+    keep_models = bool(request.config.getoption("--keep-models"))
+
+    with jubilant.temp_model(keep=keep_models) as model:
+        model.wait_timeout = 10 * 60
+
+        yield model
+
+        if request.session.testsfailed:
+            log = model.debuglog(limit=1000)
+            print(log, end="")
+
+
+@pytest.fixture(scope="module")
+def admin_tools_latest(juju: jubilant.Juju):
+    """Deploy temporal-admin-k8s from the latest track."""
+    juju.model_config(
+        values={
+            "update-status-hook-interval": "10s",
+        },
+    )
+
+    juju.deploy(
+        charm="postgresql-k8s",
+        channel="14/stable",
+        trust=True,
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        charm="temporal-k8s",
+        channel="1.23/edge",
+        config={
+            "num-history-shards": 1,
+        },
+        base="ubuntu@22.04",
+    )
+
+    juju.deploy(
+        charm="temporal-admin-k8s",
+        app="temporal-admin-k8s",
+        channel="latest/stable",
+        base="ubuntu@22.04",
+    )
+
+    juju.wait(
+        lambda status: (
+            jubilant.all_active(status, "postgresql-k8s")
+            and jubilant.all_blocked(status, "temporal-k8s", "temporal-admin-k8s")
+        ),
+    )
+
+    juju.integrate("temporal-k8s:db", "postgresql-k8s:database")
+    juju.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
+
+    juju.integrate("temporal-k8s:admin", "temporal-admin-k8s:admin")
+
+    juju.wait(jubilant.all_active)
+
+    yield "temporal-admin-k8s"
+
+
+@pytest.fixture(scope="module")
+def charm_path() -> pathlib.Path:
+    """Returns the absolute path of the locally built admin-tools-k8s charm."""
+    charm_dir = pathlib.Path(__file__).parent.parent.parent
+    charms = [p.absolute() for p in charm_dir.glob("*.charm")]
+    assert charms, "*.charm not found in project root"
+    assert len(charms) == 1, "More than one *.charm file found in project root, unsure which to use"
+    return charms[0]
+
+
+@pytest.fixture(scope="module")
+def charm_resources() -> dict:
+    """Resources to deploy the admin-tools-k8s locally built charm."""
+    metadata = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
+    return {
+        "temporal-admin-image": metadata["resources"]["temporal-admin-image"]["upstream-source"],
+    }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,10 @@ import yaml
 
 POSTGRESQL_CHANNEL = "14/stable"
 TEMPORAL_CHANNEL = "1.23/edge"
+TEMPORAL_LEGACY_CHANNEL = "latest/stable"
+
+METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
+UPSTREAM_IMAGE_SOURCE = METADATA["resources"]["temporal-admin-image"]["upstream-source"]
 
 
 @pytest.fixture(scope="module")
@@ -83,7 +87,7 @@ def deploy_temporal_stack(
 @pytest.fixture(scope="module")
 def admin_tools_latest_track(juju: jubilant.Juju):
     """Deploy temporal-admin-k8s from the latest track."""
-    deploy_temporal_stack(juju, temporal_admin_channel="latest/stable")
+    deploy_temporal_stack(juju, temporal_admin_channel=TEMPORAL_LEGACY_CHANNEL)
 
     yield "temporal-admin-k8s"
 
@@ -101,7 +105,6 @@ def charm_path() -> pathlib.Path:
 @pytest.fixture(scope="module")
 def charm_resources() -> dict:
     """Resources to deploy the admin-tools-k8s locally built charm."""
-    metadata = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
     return {
-        "temporal-admin-image": metadata["resources"]["temporal-admin-image"]["upstream-source"],
+        "temporal-admin-image": UPSTREAM_IMAGE_SOURCE,
     }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,7 @@ def juju(request: pytest.FixtureRequest):
         yield model
 
         if request.session.testsfailed:
-            log = model.debuglog(limit=1000)
+            log = model.debug_log(limit=1000)
             print(log, end="")
 
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -16,8 +16,8 @@ SERVER_APP_NAME = "temporal-k8s"
 logger = logging.getLogger(__name__)
 
 
-async def run_tctl_action(ops_test: OpsTest, namespace):
-    """Run tctl action from the admin charm to create a namespace.
+async def run_cli_action(ops_test: OpsTest, namespace):
+    """Run cli action from the admin charm to create a namespace.
 
     Args:
         ops_test: PyTest object.
@@ -26,16 +26,18 @@ async def run_tctl_action(ops_test: OpsTest, namespace):
     action = (
         await ops_test.model.applications[APP_NAME]
         .units[0]
-        .run_action("tctl", args=f"--ns {namespace} namespace register -rd 3")
+        .run_action("cli", args=f"operator namespace --namespace {namespace} create")
     )
-    result = (await action.wait()).results
+    action_output = await action.wait()
 
-    logger.info(f"tctl result: {result}")
+    logger.info(f"cli result: {action_output.results}")
 
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
     assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-    assert ("output" in result) and f"Namespace {namespace} successfully registered" in result["output"]
+    assert (
+        "output" in action_output.results
+    ) and f"Namespace {namespace} successfully registered" in action_output.results["output"]
 
 
 async def run_setup_schema_action(ops_test: OpsTest):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,8 +17,8 @@ from helpers import (
     APP_NAME,
     METADATA,
     SERVER_APP_NAME,
+    run_cli_action,
     run_setup_schema_action,
-    run_tctl_action,
 )
 from pytest_operator.plugin import OpsTest
 
@@ -33,7 +33,7 @@ async def deploy(ops_test: OpsTest):
     resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms
-    await ops_test.model.deploy(SERVER_APP_NAME, channel="edge", config={"num-history-shards": 1})
+    await ops_test.model.deploy(SERVER_APP_NAME, channel="1.23/edge", config={"num-history-shards": 1})
     await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
 
@@ -59,9 +59,9 @@ async def deploy(ops_test: OpsTest):
 class TestDeployment:
     """Integration tests for Temporal admin charm."""
 
-    async def test_tctl_action(self, ops_test: OpsTest):
-        """Is it possible to run tctl command via the action."""
-        await run_tctl_action(ops_test, namespace="default")
+    async def test_cli_action(self, ops_test: OpsTest):
+        """Is it possible to run cli command via the action."""
+        await run_cli_action(ops_test, namespace="default")
 
     async def test_setup_schema_action(self, ops_test: OpsTest):
         """Is it possible to run setup schema via the action."""
@@ -128,7 +128,7 @@ class TestDeployment:
 
         assert ops_test.model.applications[APP_NAME].status == "active"
 
-        await run_tctl_action(ops_test, namespace="integrations")
+        await run_cli_action(ops_test, namespace="integrations")
 
     async def test_remove_server(self, ops_test: OpsTest):
         """Admin charm goes to blocked state once relation with the server charm is removed."""

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test to ensure successful refreshes from latest track to the 1.23 track."""
+
+import logging
+
+import jubilant
+
+logger = logging.getLogger(__name__)
+
+
+def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest, charm_path, charm_resources):
+    """Test to refresh from latest track to the 1.23 track."""
+    juju.refresh(
+        admin_tools_latest,
+        path=charm_path,
+        resources=charm_resources,
+    )
+    juju.wait(jubilant.all_active, error=jubilant.any_error)

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -10,10 +10,10 @@ import jubilant
 logger = logging.getLogger(__name__)
 
 
-def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest, charm_path, charm_resources):
+def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_track, charm_path, charm_resources):
     """Test to refresh from latest track to the 1.23 track."""
     juju.refresh(
-        admin_tools_latest,
+        admin_tools_latest_track,
         path=charm_path,
         resources=charm_resources,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,7 @@ deps =
     pytest==7.1.3
     pytest-operator==0.42.0
     pytest-asyncio==0.21
+    jubilant~=1.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}scenario --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
We have a new temporal-server 1.23 rock which also includes all temporal admin tools.
This PR is to integrate with this rock. The new rock will update the temporal version to 1.23 + use temporal cli instead of tctl.
In addition, this PR adds a simple jubilant test to ensure that refresh from `latest` track to `1.23` is successful.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
tox -e integration -- -k "tests/integration/test_charm.py"
tox -e integration -- -k "tests/integration/test_refresh.py"


## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
