### PR TITLE
Use only image hash to avoid charmcraft upload errors

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -44,4 +44,4 @@ resources:
     type: oci-image
     description: OCI image for Temporal admin tools
     # Included for simplicity in integration tests.
-    upstream-source: ubuntu/temporal-server:1.23.1-24.04_edge@sha256:d429a4fa2ded4639a17fe3992f51648acb7e37b940c06132901c88422d8cffb2
+    upstream-source: ubuntu/temporal-server@sha256:d429a4fa2ded4639a17fe3992f51648acb7e37b940c06132901c88422d8cffb2  # 1.23-24.04


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
The PR integrating temporal-server rock in this charm used both the image hash and tag. However, `charmcraft upload-resource` is failing due to both the hash and tag being used (https://github.com/canonical/temporal-admin-k8s-operator/actions/runs/16936498961/job/47997112560) when releasing the charm.

```
  RAN: /snap/bin/charmcraft upload-resource temporal-admin-k8s 
temporal-admin-image 
--image=docker://ubuntu/temporal-server:1.23.1-24.04_edge@sha256:d429a4fa2ded463
9a17fe3992f51648acb7e37b940c06132901c88422d8cffb2 --format=json
  STDOUT:
  STDERR:
Getting image
Inspecting source image
Could not inspect OCI image: Error parsing image name 
"docker://ubuntu/temporal-server:1.23.1-24.04_edge@sha256:d429a4fa2ded4639a17fe3
992f51648acb7e37b940c06132901c88422d8cffb2": Docker references with both a tag 
and digest are currently not supported
Full execution log: 
'/home/runner/.local/state/charmcraft/log/charmcraft-20250813-123940.354527.log'
```

This PR uses only the hash to ensure that the precise tested image is the one being used in the charm. We avoid using the tag since that tag is an alias that can be updated with a new release of the image.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
