### PR TITLE
[WF-334] Add temporal-host-info relation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Please check the
 [Temporal server operator](https://charmhub.io/temporal-k8s)
 for usage instructions.
 
+### Temporal endpoint resolution
+
+`temporal-host-info` relation is the preferred source of Temporal server address. If relation data is unavailable, the deprecated `server-name` config option is used as a temporary fallback for upgrade compatibility.
+
+`server-name` is deprecated and will be removed in a future release. Prefer integrating `temporal-host-info` relation instead of relying on config fallback.
+
 ## Contributing
 
 This charm is still in active development. Please see the

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,6 @@ options:
     type: string
   server-name:
     description: |
-        The name with which the Temporal server frontend service is deployed.
+        [DEPRECATED] The name with which the Temporal server frontend service is deployed.
     default: "temporal-k8s"
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,9 @@ options:
     type: string
   server-name:
     description: |
-        [DEPRECATED] The name with which the Temporal server frontend service is deployed.
-    default: "temporal-k8s"
+        [DEPRECATED] Optional fallback Temporal server frontend service name when
+        `temporal-host-info` relation is unavailable.
+        Leave empty to require `temporal-host-info` only. If set, this option is
+        deprecated and will be removed in a future release; prefer the relation.
+    default: ""
     type: string

--- a/lib/charms/temporal_k8s/v0/temporal_host_info.py
+++ b/lib/charms/temporal_k8s/v0/temporal_host_info.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+from ops import (
+    ConfigChangedEvent,
+    Handle,
+    LeaderElectedEvent,
+    RelationChangedEvent,
+    RelationJoinedEvent,
+    framework,
+)
+from ops.charm import CharmBase
+from ops.framework import EventBase, EventSource, ObjectEvents
+from ops.model import ActiveStatus, Relation, WaitingStatus
+
+# The unique Charmhub library identifier, never change it
+LIBID = "024db27b47e546628c9ed7f26ddad6c8"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+RELATION_NAME = "temporal-host-info"
+
+logger = logging.getLogger(__name__)
+
+
+class TemporalHostInfoProvider(framework.Object):
+    """A class for managing the temporal-host-info interface provider."""
+
+    def __init__(self, charm: CharmBase, port: int):
+        """Create a new instance of the TemporalHostInfoProvider class.
+
+        :param: charm: The charm that is using this interface.
+        :type charm: CharmBase
+        :param: port: The port number to provide to requirers. This is typically
+            the 'frontend' service port.
+        :type port: int
+        """
+        super().__init__(charm, "temporal_host_info_provider")
+        self.charm = charm
+        self.port = port
+        charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on.leader_elected, self._on_config_changed)
+        charm.framework.observe(charm.on.config_changed, self._on_config_changed)
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent | RelationJoinedEvent):
+        """Update relation data.
+
+        :param: event: The relation event that triggered this handler.
+        :type event: RelationChangedEvent | RelationJoinedEvent
+        """
+        logger.info("Handling temporal-host-info relation event")
+        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
+            host = str(self.charm.config["external-hostname"])
+            if binding := self.charm.model.get_binding(event.relation):
+                host = host or str(binding.network.bind_address)
+            event.relation.data[self.charm.app]["host"] = host
+            event.relation.data[self.charm.app]["port"] = str(self.port)
+
+    def _on_config_changed(self, event: ConfigChangedEvent | LeaderElectedEvent):
+        """Update relation data on config change."""
+        logger.info("Config changed, updating temporal-host-info relation data")
+        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
+            host = str(self.charm.config["external-hostname"])
+            for relation in self.charm.model.relations.get("temporal-host-info", []):
+                if binding := self.charm.model.get_binding(relation):
+                    host = host or str(binding.network.bind_address)
+                relation.data[self.charm.app]["host"] = host
+                relation.data[self.charm.app]["port"] = str(self.port)
+
+
+class TemporalHostInfoRelationReadyEvent(EventBase):
+    """Event emitted when temporal-host-info relation is ready."""
+
+    def __init__(
+        self,
+        handle: Handle,
+        host: str,
+        port: int,
+    ):
+        super().__init__(handle)
+        self.host = host
+        self.port = port
+
+    def snapshot(self) -> dict[str, str | int]:
+        """Return a snapshot of the event."""
+        data = super().snapshot()
+        data.update({"host": self.host, "port": self.port})
+        return data
+
+    def restore(self, snapshot: dict[str, str | int]) -> None:
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.host = snapshot["host"]
+        self.port = snapshot["port"]
+
+
+class TemporalHostInfoRequirerCharmEvents(ObjectEvents):
+    """List of events that the requirer charm can leverage."""
+
+    temporal_host_info_available = EventSource(TemporalHostInfoRelationReadyEvent)
+
+
+class TemporalHostInfoRequirer(framework.Object):
+    """A class for managing the temporal-host-info interface requirer.
+
+    Track this relation in your charm with:
+
+    .. code-block:: python
+
+        self.host_info = TemporalHostInfoRequirer(self)
+        # update container with new host info
+        framework.observe(self.host_info.on.temporal_host_info_available, self._update)
+
+        def _update(self, event):
+            host = self.host_info.host
+            port = self.host_info.port
+    """
+
+    on = TemporalHostInfoRequirerCharmEvents()  # type: ignore[reportAssignmentType]
+
+    def __init__(self, charm: CharmBase):
+        """Create a new instance of the TemporalHostInfoProvider class.
+
+        :param: charm: The charm that is using this interface.
+        :type charm: CharmBase
+        """
+        super().__init__(charm, "temporal_host_info_requirer")
+        self.charm = charm
+        charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+
+    @property
+    def relations(self) -> list[Relation]:
+        """Return the relations for this interface."""
+        return self.charm.model.relations.get(RELATION_NAME, [])
+
+    @property
+    def host(self) -> str | None:
+        """Return the host from the relation data."""
+        for relation in self.relations:
+            if relation and relation.app:
+                return relation.data[relation.app].get("host", None)
+        return None
+
+    @property
+    def port(self) -> int | None:
+        """Return the port from the relation data."""
+        for relation in self.relations:
+            if relation and relation.app:
+                port_str = relation.data[relation.app].get("port", None)
+                if port_str is not None:
+                    return int(port_str)
+        return None
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent):
+        """Handle the relation joined/changed events.
+
+        :param: event: The relation event that triggered this handler.
+        :type event: RelationChangedEvent | RelationJoinedEvent
+        """
+        try:
+            host = event.relation.data[event.relation.app]["host"]
+            port = int(event.relation.data[event.relation.app]["port"])
+        except KeyError:
+            self.charm.unit.status = WaitingStatus("Waiting for temporal-host-info provider")
+            event.defer()
+            return
+        self.charm.unit.status = ActiveStatus()
+        self.on.temporal_host_info_available.emit(host=host, port=port)

--- a/lib/charms/temporal_k8s/v0/temporal_host_info.py
+++ b/lib/charms/temporal_k8s/v0/temporal_host_info.py
@@ -1,5 +1,12 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+"""Charm library for the temporal-host-info relation interface.
+
+This library provides the TemporalHostInfoProvider and TemporalHostInfoRequirer
+classes for charms that need to share Temporal server connection details
+(host and port) over a Juju relation.
+"""
 
 import logging
 
@@ -7,13 +14,15 @@ from ops import (
     ConfigChangedEvent,
     Handle,
     LeaderElectedEvent,
+    Object,
+    RelationBrokenEvent,
     RelationChangedEvent,
     RelationJoinedEvent,
-    framework,
+    TooManyRelatedAppsError,
 )
 from ops.charm import CharmBase
 from ops.framework import EventBase, EventSource, ObjectEvents
-from ops.model import ActiveStatus, Relation, WaitingStatus
+from ops.model import Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "024db27b47e546628c9ed7f26ddad6c8"
@@ -30,7 +39,7 @@ RELATION_NAME = "temporal-host-info"
 logger = logging.getLogger(__name__)
 
 
-class TemporalHostInfoProvider(framework.Object):
+class TemporalHostInfoProvider(Object):
     """A class for managing the temporal-host-info interface provider."""
 
     def __init__(self, charm: CharmBase, port: int):
@@ -56,28 +65,49 @@ class TemporalHostInfoProvider(framework.Object):
         :param: event: The relation event that triggered this handler.
         :type event: RelationChangedEvent | RelationJoinedEvent
         """
-        logger.info("Handling temporal-host-info relation event")
-        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
-            host = str(self.charm.config["external-hostname"])
-            if binding := self.charm.model.get_binding(event.relation):
-                host = host or str(binding.network.bind_address)
-            event.relation.data[self.charm.app]["host"] = host
-            event.relation.data[self.charm.app]["port"] = str(self.port)
+        logger.debug("Handling temporal-host-info relation event")
+        if not self.charm.unit.is_leader() or "frontend" not in str(self.charm.config["services"]):
+            return
+        host = self._resolve_host(event.relation)
+        app_data = event.relation.data[self.charm.app]
+        app_data["host"] = host
+        app_data["port"] = str(self.port)
 
     def _on_config_changed(self, event: ConfigChangedEvent | LeaderElectedEvent):
-        """Update relation data on config change."""
-        logger.info("Config changed, updating temporal-host-info relation data")
-        if self.charm.unit.is_leader() and "frontend" in str(self.charm.config["services"]):
-            host = str(self.charm.config["external-hostname"])
-            for relation in self.charm.model.relations.get("temporal-host-info", []):
-                if binding := self.charm.model.get_binding(relation):
-                    host = host or str(binding.network.bind_address)
-                relation.data[self.charm.app]["host"] = host
-                relation.data[self.charm.app]["port"] = str(self.port)
+        """Update relation data on config change or leader election.
+
+        :param: event: The event that triggered this handler.
+        :type event: ConfigChangedEvent | LeaderElectedEvent
+        """
+        logger.debug("Config changed, updating temporal-host-info relation data")
+        if not self.charm.unit.is_leader() or "frontend" not in str(self.charm.config["services"]):
+            return
+        for relation in self.charm.model.relations.get(RELATION_NAME, []):
+            host = self._resolve_host(relation)
+            app_data = relation.data[self.charm.app]
+            app_data["host"] = host
+            app_data["port"] = str(self.port)
+
+    def _resolve_host(self, relation: Relation) -> str:
+        """Resolve host to external-hostname or relation binding address.
+
+        :param: relation: The relation to resolve the host for.
+        :type relation: Relation
+        :returns: The resolved host string.
+        :rtype: str
+        """
+        host = str(self.charm.config["external-hostname"])
+        if not host:
+            binding = self.charm.model.get_binding(relation)
+            if binding:
+                host = str(binding.network.bind_address)
+        if not host:
+            logger.warning("Could not resolve host: external-hostname is not set and no binding address is available")
+        return host
 
 
-class TemporalHostInfoRelationReadyEvent(EventBase):
-    """Event emitted when temporal-host-info relation is ready."""
+class TemporalHostInfoChangedEvent(EventBase):
+    """Event emitted when temporal-host-info relation data changes."""
 
     def __init__(
         self,
@@ -105,10 +135,12 @@ class TemporalHostInfoRelationReadyEvent(EventBase):
 class TemporalHostInfoRequirerCharmEvents(ObjectEvents):
     """List of events that the requirer charm can leverage."""
 
-    temporal_host_info_available = EventSource(TemporalHostInfoRelationReadyEvent)
+    temporal_host_info_changed = EventSource(TemporalHostInfoChangedEvent)
+    # No data to snapshot/restore here, so we can just use EventBase
+    temporal_host_info_unavailable = EventSource(EventBase)
 
 
-class TemporalHostInfoRequirer(framework.Object):
+class TemporalHostInfoRequirer(Object):
     """A class for managing the temporal-host-info interface requirer.
 
     Track this relation in your charm with:
@@ -117,9 +149,9 @@ class TemporalHostInfoRequirer(framework.Object):
 
         self.host_info = TemporalHostInfoRequirer(self)
         # update container with new host info
-        framework.observe(self.host_info.on.temporal_host_info_available, self._update)
+        framework.observe(self.host_info.on.temporal_host_info_changed, self._on_host_info_changed)
 
-        def _update(self, event):
+        def _on_host_info_changed(self, event):
             host = self.host_info.host
             port = self.host_info.port
     """
@@ -127,51 +159,62 @@ class TemporalHostInfoRequirer(framework.Object):
     on = TemporalHostInfoRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase):
-        """Create a new instance of the TemporalHostInfoProvider class.
+        """Create a new instance of the TemporalHostInfoRequirer class.
 
         :param: charm: The charm that is using this interface.
         :type charm: CharmBase
         """
         super().__init__(charm, "temporal_host_info_requirer")
         self.charm = charm
+        try:
+            self.charm.model.get_relation(RELATION_NAME)
+        except TooManyRelatedAppsError:
+            raise RuntimeError(f"Multiple {RELATION_NAME} relations are not supported for requirers.")
         charm.framework.observe(charm.on[RELATION_NAME].relation_joined, self._on_host_info_relation_changed)
         charm.framework.observe(charm.on[RELATION_NAME].relation_changed, self._on_host_info_relation_changed)
+        charm.framework.observe(charm.on[RELATION_NAME].relation_broken, self._on_host_info_relation_broken)
 
     @property
-    def relations(self) -> list[Relation]:
-        """Return the relations for this interface."""
-        return self.charm.model.relations.get(RELATION_NAME, [])
+    def relation(self) -> Relation | None:
+        """Return the relation for this interface, if any."""
+        return self.charm.model.get_relation(RELATION_NAME)
 
     @property
     def host(self) -> str | None:
         """Return the host from the relation data."""
-        for relation in self.relations:
-            if relation and relation.app:
-                return relation.data[relation.app].get("host", None)
+        relation = self.relation
+        if relation and relation.app:
+            return relation.data[relation.app].get("host", None)
         return None
 
     @property
     def port(self) -> int | None:
         """Return the port from the relation data."""
-        for relation in self.relations:
-            if relation and relation.app:
-                port_str = relation.data[relation.app].get("port", None)
-                if port_str is not None:
-                    return int(port_str)
+        relation = self.relation
+        if relation and relation.app:
+            port_str = relation.data[relation.app].get("port", None)
+            if port_str is not None:
+                return int(port_str)
         return None
 
-    def _on_host_info_relation_changed(self, event: RelationChangedEvent):
+    def _on_host_info_relation_broken(self, event: RelationBrokenEvent):
+        """Handle the relation broken event.
+
+        :param: event: The relation broken event that triggered this handler.
+        :type event: RelationBrokenEvent
+        """
+        self.on.temporal_host_info_unavailable.emit()
+
+    def _on_host_info_relation_changed(self, event: RelationChangedEvent | RelationJoinedEvent):
         """Handle the relation joined/changed events.
 
         :param: event: The relation event that triggered this handler.
         :type event: RelationChangedEvent | RelationJoinedEvent
         """
+        app_data = event.relation.data[event.relation.app]
         try:
-            host = event.relation.data[event.relation.app]["host"]
-            port = int(event.relation.data[event.relation.app]["port"])
+            host = app_data["host"]
+            port = int(app_data["port"])
         except KeyError:
-            self.charm.unit.status = WaitingStatus("Waiting for temporal-host-info provider")
-            event.defer()
             return
-        self.charm.unit.status = ActiveStatus()
-        self.on.temporal_host_info_available.emit(host=host, port=port)
+        self.on.temporal_host_info_changed.emit(host=host, port=port)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -38,6 +38,7 @@ provides:
 requires:
   temporal-host-info:
     interface: temporal-host-info
+    limit: 1
 
 containers:
   temporal-admin:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ summary: Temporal admin tools operator
 description: |
   Temporal is a developer-first, open source platform that ensures
   the successful execution of services and applications (using workflows).
-maintainers: 
+maintainers:
   - Commercial Systems <jaas-crew@lists.canonical.com>
 docs: https://discourse.charmhub.io/t/temporal-admin-documentation-overview/8939
 source: https://github.com/canonical/temporal-admin-k8s-operator
@@ -34,6 +34,10 @@ provides:
   admin:
     interface: temporal
     limit: 4
+
+requires:
+  temporal-host-info:
+    interface: temporal-host-info
 
 containers:
   temporal-admin:

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,6 @@ import json
 import logging
 
 from charms.temporal_k8s.v0.temporal_host_info import TemporalHostInfoRequirer
-
 from ops import main
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -152,12 +151,12 @@ class TemporalAdminK8SCharm(CharmBase):
             return
 
         server_name = self.host_info.host or "temporal-k8s"
+        server_port = self.host_info.port or 7236
         if self.config["server-name"] != "temporal-k8s":
-            logger.warning(
-                "The 'server-name' config option is deprecated and will be removed in a future release."
-            )
+            logger.warning("The 'server-name' config option is deprecated and will be removed in a future release.")
             server_name = self.config["server-name"]
-        args = ["--address", f"{server_name}:7236", *event.params["args"].split()]
+            server_port = 7236
+        args = ["--address", f"{server_name}:{server_port}", *event.params["args"].split()]
         try:
             output = execute(container, "temporal", *args)
         except Exception as err:

--- a/src/charm.py
+++ b/src/charm.py
@@ -164,18 +164,16 @@ class TemporalAdminK8SCharm(CharmBase):
         if self.host_info.host and self.host_info.port:
             server_name = self.host_info.host
             server_port = self.host_info.port
+        elif deprecated := self._deprecated_server_name:
+            logger.warning(
+                "The `server-name` config option is deprecated and will be removed in a future release; "
+                "prefer the `temporal-host-info` relation."
+            )
+            server_name = deprecated
+            server_port = 7236
         else:
-            deprecated = self._deprecated_server_name
-            if deprecated:
-                logger.warning(
-                    "The `server-name` config option is deprecated and will be removed in a future release; "
-                    "prefer the `temporal-host-info` relation."
-                )
-                server_name = deprecated
-                server_port = 7236
-            else:
-                event.fail("temporal-host-info relation not established; set deprecated server-name config as fallback")
-                return
+            event.fail("temporal-host-info relation not established; set deprecated server-name config as fallback")
+            return
         args = ["--address", f"{server_name}:{server_port}", *event.params["args"].split()]
         try:
             output = execute(container, "temporal", *args)

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,6 +10,8 @@ import functools
 import json
 import logging
 
+from charms.temporal_k8s.v0.temporal_host_info import TemporalHostInfoRequirer
+
 from ops import main
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
@@ -73,6 +75,9 @@ class TemporalAdminK8SCharm(CharmBase):
         # Handle action
         self.framework.observe(self.on.cli_action, self._on_cli_action)
         self.framework.observe(self.on.setup_schema_action, self._on_setup_schema_action)
+
+        # Handle temporal-host-info relation.
+        self.host_info = TemporalHostInfoRequirer(self)
 
     @log_event_handler
     def _on_install(self, event):
@@ -146,7 +151,7 @@ class TemporalAdminK8SCharm(CharmBase):
             event.fail("cannot connect to container")
             return
 
-        server_name = self.model.config["server-name"] or "temporal-k8s"
+        server_name = self.host_info.host or "temporal-k8s"
         args = ["--address", f"{server_name}:7236", *event.params["args"].split()]
         try:
             output = execute(container, "temporal", *args)

--- a/src/charm.py
+++ b/src/charm.py
@@ -78,6 +78,15 @@ class TemporalAdminK8SCharm(CharmBase):
         # Handle temporal-host-info relation.
         self.host_info = TemporalHostInfoRequirer(self)
 
+    @property
+    def _deprecated_server_name(self) -> str | None:
+        """Return configured fallback server name, if set."""
+        raw = self.config.get("server-name")
+        if raw is None:
+            return None
+        stripped = str(raw).strip()
+        return stripped or None
+
     @log_event_handler
     def _on_install(self, event):
         """Install temporal admin tools.
@@ -150,12 +159,23 @@ class TemporalAdminK8SCharm(CharmBase):
             event.fail("cannot connect to container")
             return
 
-        server_name = self.host_info.host or "temporal-k8s"
-        server_port = self.host_info.port or 7236
-        if self.config["server-name"] != "temporal-k8s":
-            logger.warning("The 'server-name' config option is deprecated and will be removed in a future release.")
-            server_name = self.config["server-name"]
-            server_port = 7236
+        # Relation data is authoritative when available. For upgrade compatibility,
+        # fallback to deprecated `server-name` only when explicitly configured.
+        if self.host_info.host and self.host_info.port:
+            server_name = self.host_info.host
+            server_port = self.host_info.port
+        else:
+            deprecated = self._deprecated_server_name
+            if deprecated:
+                logger.warning(
+                    "The `server-name` config option is deprecated and will be removed in a future release; "
+                    "prefer the `temporal-host-info` relation."
+                )
+                server_name = deprecated
+                server_port = 7236
+            else:
+                event.fail("temporal-host-info relation not established; set deprecated server-name config as fallback")
+                return
         args = ["--address", f"{server_name}:{server_port}", *event.params["args"].split()]
         try:
             output = execute(container, "temporal", *args)

--- a/src/charm.py
+++ b/src/charm.py
@@ -152,6 +152,11 @@ class TemporalAdminK8SCharm(CharmBase):
             return
 
         server_name = self.host_info.host or "temporal-k8s"
+        if self.config["server-name"] != "temporal-k8s":
+            logger.warning(
+                "The 'server-name' config option is deprecated and will be removed in a future release."
+            )
+            server_name = self.config["server-name"]
         args = ["--address", f"{server_name}:7236", *event.params["args"].split()]
         try:
             output = execute(container, "temporal", *args)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import yaml
 POSTGRESQL_CHANNEL = "14/stable"
 TEMPORAL_CHANNEL = "1.23/edge"
 TEMPORAL_LEGACY_CHANNEL = "latest/stable"
+TEMPORAL_SERVER_APP_NAME = "temporal-k8s"
 
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
 UPSTREAM_IMAGE_SOURCE = METADATA["resources"]["temporal-admin-image"]["upstream-source"]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -67,7 +67,7 @@ def deploy_temporal_stack(
         config={
             "num-history-shards": 1,
         },
-        base="ubuntu@22.04",
+        base="ubuntu@24.04",
     )
 
     juju.deploy(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -64,7 +64,8 @@ class TestDeployment:
         await run_cli_action(ops_test, namespace="default")
 
     async def test_host_info_relation(self, ops_test: OpsTest):
-        """Add temporal-host-info relation and verify cli action works."""
+        """Relation values should take precedence over deprecated config fallback."""
+        await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
         await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
@@ -75,7 +76,8 @@ class TestDeployment:
         await run_cli_action(ops_test, namespace="host-info")
 
     async def test_host_info_relation_removed_uses_fallback(self, ops_test: OpsTest):
-        """Remove temporal-host-info relation and verify cli action still works."""
+        """Remove host-info relation and verify deprecated config fallback still works."""
+        await ops_test.model.applications[APP_NAME].set_config({"server-name": SERVER_APP_NAME})
         await ops_test.juju(
             "remove-relation",
             f"{SERVER_APP_NAME}:temporal-host-info",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -53,9 +53,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
         try:
-            await ops_test.model.integrate(
-                f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info"
-            )
+            await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
         except JujuAPIError as exc:
             # Older temporal-k8s revisions may not expose temporal-host-info yet.
             if "temporal-host-info" in str(exc) and "has no" in str(exc):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,14 +20,18 @@ from helpers import (
     run_cli_action,
     run_setup_schema_action,
 )
+from juju.errors import JujuAPIError
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
+HOST_INFO_RELATION_AVAILABLE = True
 
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
+    global HOST_INFO_RELATION_AVAILABLE  # pylint: disable=global-statement
+
     await ops_test.model.set_config({"update-status-hook-interval": "1m"})
     charm = await ops_test.build_charm(".")
     resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
@@ -48,9 +52,17 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:db", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
-        await ops_test.model.integrate(
-            f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info"
-        )
+        try:
+            await ops_test.model.integrate(
+                f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info"
+            )
+        except JujuAPIError as exc:
+            # Older temporal-k8s revisions may not expose temporal-host-info yet.
+            if "temporal-host-info" in str(exc) and "has no" in str(exc):
+                HOST_INFO_RELATION_AVAILABLE = False
+                await ops_test.model.applications[APP_NAME].set_config({"server-name": SERVER_APP_NAME})
+            else:
+                raise
 
         await ops_test.model.wait_for_idle(apps=[SERVER_APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
@@ -68,6 +80,9 @@ class TestDeployment:
 
     async def test_host_info_relation(self, ops_test: OpsTest):
         """Relation values should take precedence over deprecated config fallback."""
+        if not HOST_INFO_RELATION_AVAILABLE:
+            pytest.skip("temporal-host-info endpoint not available in deployed temporal-k8s revision")
+
         await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
         await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
         await ops_test.model.wait_for_idle(
@@ -80,6 +95,9 @@ class TestDeployment:
 
     async def test_host_info_relation_removed_uses_fallback(self, ops_test: OpsTest):
         """Remove host-info relation and verify deprecated config fallback still works."""
+        if not HOST_INFO_RELATION_AVAILABLE:
+            pytest.skip("temporal-host-info endpoint not available in deployed temporal-k8s revision")
+
         await ops_test.model.applications[APP_NAME].set_config({"server-name": SERVER_APP_NAME})
         await ops_test.juju(
             "remove-relation",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -74,6 +74,21 @@ class TestDeployment:
         )
         await run_cli_action(ops_test, namespace="host-info")
 
+    async def test_host_info_relation_removed_uses_fallback(self, ops_test: OpsTest):
+        """Remove temporal-host-info relation and verify cli action still works."""
+        await ops_test.juju(
+            "remove-relation",
+            f"{SERVER_APP_NAME}:temporal-host-info",
+            f"{APP_NAME}:temporal-host-info",
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await run_cli_action(ops_test, namespace="host-info-fallback")
+
     async def test_setup_schema_action(self, ops_test: OpsTest):
         """Is it possible to run setup schema via the action."""
         await run_setup_schema_action(ops_test)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -48,6 +48,9 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:db", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
+        await ops_test.model.integrate(
+            f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info"
+        )
 
         await ops_test.model.wait_for_idle(apps=[SERVER_APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,6 +13,7 @@ import time
 
 import pytest
 import pytest_asyncio
+from pytest import FixtureRequest
 from helpers import (
     APP_NAME,
     METADATA,
@@ -26,10 +27,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
-async def deploy(ops_test: OpsTest):
+async def deploy(ops_test: OpsTest, request: FixtureRequest):
     """The app is up and running."""
     await ops_test.model.set_config({"update-status-hook-interval": "1m"})
-    charm = await ops_test.build_charm(".")
+    charm_paths = request.config.getoption("--charm-file")
+    if charm_paths:
+        charm = charm_paths[0]
+    else:
+        charm = await ops_test.build_charm(".")
     resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
 
     # Deploy temporal server, temporal admin and postgresql charms

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,18 +20,14 @@ from helpers import (
     run_cli_action,
     run_setup_schema_action,
 )
-from juju.errors import JujuAPIError
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
-HOST_INFO_RELATION_AVAILABLE = True
 
 
 @pytest_asyncio.fixture(name="deploy", scope="module")
 async def deploy(ops_test: OpsTest):
     """The app is up and running."""
-    global HOST_INFO_RELATION_AVAILABLE  # pylint: disable=global-statement
-
     await ops_test.model.set_config({"update-status-hook-interval": "1m"})
     charm = await ops_test.build_charm(".")
     resources = {"temporal-admin-image": METADATA["resources"]["temporal-admin-image"]["upstream-source"]}
@@ -52,15 +48,7 @@ async def deploy(ops_test: OpsTest):
         await ops_test.model.integrate("temporal-k8s:db", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:visibility", "postgresql-k8s:database")
         await ops_test.model.integrate("temporal-k8s:admin", f"{APP_NAME}:admin")
-        try:
-            await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
-        except JujuAPIError as exc:
-            # Older temporal-k8s revisions may not expose temporal-host-info yet.
-            if "temporal-host-info" in str(exc) and "has no" in str(exc):
-                HOST_INFO_RELATION_AVAILABLE = False
-                await ops_test.model.applications[APP_NAME].set_config({"server-name": SERVER_APP_NAME})
-            else:
-                raise
+        await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
 
         await ops_test.model.wait_for_idle(apps=[SERVER_APP_NAME], status="active", raise_on_blocked=False, timeout=600)
 
@@ -78,11 +66,7 @@ class TestDeployment:
 
     async def test_host_info_relation(self, ops_test: OpsTest):
         """Relation values should take precedence over deprecated config fallback."""
-        if not HOST_INFO_RELATION_AVAILABLE:
-            pytest.skip("temporal-host-info endpoint not available in deployed temporal-k8s revision")
-
         await ops_test.model.applications[APP_NAME].set_config({"server-name": "deprecated-host"})
-        await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",
@@ -93,9 +77,6 @@ class TestDeployment:
 
     async def test_host_info_relation_removed_uses_fallback(self, ops_test: OpsTest):
         """Remove host-info relation and verify deprecated config fallback still works."""
-        if not HOST_INFO_RELATION_AVAILABLE:
-            pytest.skip("temporal-host-info endpoint not available in deployed temporal-k8s revision")
-
         await ops_test.model.applications[APP_NAME].set_config({"server-name": SERVER_APP_NAME})
         await ops_test.juju(
             "remove-relation",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,7 +63,6 @@ class TestDeployment:
         """Is it possible to run cli command via the action."""
         await run_cli_action(ops_test, namespace="default")
 
-
     async def test_host_info_relation(self, ops_test: OpsTest):
         """Add temporal-host-info relation and verify cli action works."""
         await ops_test.model.integrate("temporal-k8s:temporal-host-info", f"{APP_NAME}:temporal-host-info")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -65,7 +65,7 @@ class TestDeployment:
 
     async def test_host_info_relation(self, ops_test: OpsTest):
         """Add temporal-host-info relation and verify cli action works."""
-        await ops_test.model.integrate("temporal-k8s:temporal-host-info", f"{APP_NAME}:temporal-host-info")
+        await ops_test.model.integrate(f"{SERVER_APP_NAME}:temporal-host-info", f"{APP_NAME}:temporal-host-info")
         await ops_test.model.wait_for_idle(
             apps=[APP_NAME],
             status="active",

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,7 +13,6 @@ import time
 
 import pytest
 import pytest_asyncio
-from pytest import FixtureRequest
 from helpers import (
     APP_NAME,
     METADATA,
@@ -21,6 +20,7 @@ from helpers import (
     run_cli_action,
     run_setup_schema_action,
 )
+from pytest import FixtureRequest
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,6 +63,18 @@ class TestDeployment:
         """Is it possible to run cli command via the action."""
         await run_cli_action(ops_test, namespace="default")
 
+
+    async def test_host_info_relation(self, ops_test: OpsTest):
+        """Add temporal-host-info relation and verify cli action works."""
+        await ops_test.model.integrate("temporal-k8s:temporal-host-info", f"{APP_NAME}:temporal-host-info")
+        await ops_test.model.wait_for_idle(
+            apps=[APP_NAME],
+            status="active",
+            raise_on_blocked=False,
+            timeout=600,
+        )
+        await run_cli_action(ops_test, namespace="host-info")
+
     async def test_setup_schema_action(self, ops_test: OpsTest):
         """Is it possible to run setup schema via the action."""
         await run_setup_schema_action(ops_test)

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -28,7 +28,7 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_tra
         # During upgrade testing, temporal-k8s may still be on a legacy revision
         # that does not expose temporal-host-info. In that case, use deprecated
         # server-name as a compatibility fallback.
-        if "temporal-host-info" in str(exc) and "has no relation" in str(exc):
+        if "temporal-host-info" in str(exc) and "has no" in str(exc):
             juju.cli("config", admin_tools_latest_track, f"server-name={TEMPORAL_SERVER_APP_NAME}")
         else:
             raise

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -19,9 +19,18 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_tra
         resources=charm_resources,
     )
 
-    juju.integrate(
-        f"{TEMPORAL_SERVER_APP_NAME}:temporal-host-info",
-        f"{admin_tools_latest_track}:temporal-host-info",
-    )
+    try:
+        juju.integrate(
+            f"{TEMPORAL_SERVER_APP_NAME}:temporal-host-info",
+            f"{admin_tools_latest_track}:temporal-host-info",
+        )
+    except jubilant.CLIError as exc:
+        # During upgrade testing, temporal-k8s may still be on a legacy revision
+        # that does not expose temporal-host-info. In that case, use deprecated
+        # server-name as a compatibility fallback.
+        if "temporal-host-info" in str(exc) and "has no relation" in str(exc):
+            juju.cli("config", admin_tools_latest_track, f"server-name={TEMPORAL_SERVER_APP_NAME}")
+        else:
+            raise
 
     juju.wait(jubilant.all_active, error=jubilant.any_error)

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -6,6 +6,7 @@
 import logging
 
 import jubilant
+from conftest import TEMPORAL_SERVER_APP_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -17,4 +18,10 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_tra
         path=charm_path,
         resources=charm_resources,
     )
+
+    juju.integrate(
+        f"{TEMPORAL_SERVER_APP_NAME}:temporal-host-info",
+        f"{admin_tools_latest_track}:temporal-host-info",
+    )
+
     juju.wait(jubilant.all_active, error=jubilant.any_error)

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -3,12 +3,8 @@
 
 """Test to ensure successful refreshes from latest track to the 1.23 track."""
 
-import logging
-
 import jubilant
 from conftest import TEMPORAL_SERVER_APP_NAME
-
-logger = logging.getLogger(__name__)
 
 
 def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_track, charm_path, charm_resources):
@@ -19,18 +15,9 @@ def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_tra
         resources=charm_resources,
     )
 
-    try:
-        juju.integrate(
-            f"{TEMPORAL_SERVER_APP_NAME}:temporal-host-info",
-            f"{admin_tools_latest_track}:temporal-host-info",
-        )
-    except jubilant.CLIError as exc:
-        # During upgrade testing, temporal-k8s may still be on a legacy revision
-        # that does not expose temporal-host-info. In that case, use deprecated
-        # server-name as a compatibility fallback.
-        if "temporal-host-info" in str(exc) and "has no" in str(exc):
-            juju.cli("config", admin_tools_latest_track, f"server-name={TEMPORAL_SERVER_APP_NAME}")
-        else:
-            raise
+    juju.integrate(
+        f"{TEMPORAL_SERVER_APP_NAME}:temporal-host-info",
+        f"{admin_tools_latest_track}:temporal-host-info",
+    )
 
     juju.wait(jubilant.all_active, error=jubilant.any_error)


### PR DESCRIPTION
## Description
Adds the `temporal-host-info` relation with the `temporal-k8s` charm. Depends on https://github.com/canonical/temporal-k8s-operator/pull/114

---
## Testing instructions
1. Build charm
2. Verify a namespace can be created without relation.
3. integrate `temporal-admin-k8s:temporal-host-info` with `temporal-k8s:temporal-host-info`
4. Verify a namespace can still be created.

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
