### PR TITLE
[WF-203] Use juju provider v1.0.0

### DIFF
--- a/terraform/justfile
+++ b/terraform/justfile
@@ -46,9 +46,11 @@ validate_test_tfvars variables_file:
 
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
+    #!/usr/bin/bash
     terraform destroy -auto-approve -var-file="${variables_file}"
 
     just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
 
 test:
     #!/usr/bin/bash

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -35,6 +35,15 @@ lint:
 apply variables_file: (initialize)
     terraform apply -auto-approve -var-file="${variables_file}"
 
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
 # Destroy the terraform plan with the provided variables file
 destroy variables_file:
     terraform destroy -auto-approve -var-file="${variables_file}"
@@ -48,6 +57,8 @@ test:
     trap 'just destroy "./test/test.tfvars"' EXIT
 
     just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
 
     just apply "./test/test.tfvars"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,6 @@
 resource "juju_application" "temporal_admin_k8s" {
   name  = var.app_name
-  model = var.model
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-admin-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,11 @@
+data "juju_model" "terraform" {
+  name  = "terraform"
+  owner = "admin"
+}
+
 resource "juju_application" "temporal_admin_k8s" {
-  name  = var.app_name
-  model_uuid = var.model_uuid
+  name       = var.app_name
+  model_uuid = data.juju_model.terraform.uuid
 
   charm {
     name     = "temporal-admin-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,11 @@
-data "juju_model" "terraform" {
-  name  = "terraform"
+data "juju_model" "terraform_model" {
+  name  = var.model
   owner = "admin"
 }
 
 resource "juju_application" "temporal_admin_k8s" {
   name       = var.app_name
-  model_uuid = data.juju_model.terraform.uuid
+  model_uuid = data.juju_model.terraform_model.uuid
 
   charm {
     name     = "temporal-admin-k8s"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,6 @@
-data "juju_model" "terraform_model" {
-  name  = var.model
-  owner = "admin"
-}
-
 resource "juju_application" "temporal_admin_k8s" {
   name       = var.app_name
-  model_uuid = data.juju_model.terraform_model.uuid
+  model_uuid = var.model_uuid
 
   charm {
     name     = "temporal-admin-k8s"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,2 +1,1 @@
-model   = "terraform"
 channel = "1.23/edge"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,2 +1,1 @@
 channel = "1.23/edge"
-model_uuid = "8a491f55-db43-4d2d-8b3c-887186971776"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,1 +1,2 @@
+model = "terraform"
 channel = "1.23/edge"

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,2 +1,2 @@
-model = "terraform"
 channel = "1.23/edge"
+model_uuid = "8a491f55-db43-4d2d-8b3c-887186971776"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,7 +10,7 @@ variable "units" {
   default     = 1
 }
 
-variable "model" {
+variable "model_uuid" {
   type        = string
   description = "Juju model where the application is to be deployed"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,15 +4,15 @@ variable "app_name" {
   default     = "temporal-admin-k8s"
 }
 
-variable "model" {
-  description = "Reference to an existing model resource or data source for the model to deploy to."
-  type        = string
-}
-
 variable "units" {
   type        = number
   description = "Number of units to deploy with this name and configuration"
   default     = 1
+}
+
+variable "model_uuid" {
+  type = string
+  description = "UUID of the Juju model where the application is to be deployed"
 }
 
 variable "revision" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,11 +10,6 @@ variable "units" {
   default     = 1
 }
 
-variable "model_uuid" {
-  type        = string
-  description = "Juju model where the application is to be deployed"
-}
-
 variable "revision" {
   type        = number
   description = "Revision of the charm to deploy"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,11 @@ variable "app_name" {
   default     = "temporal-admin-k8s"
 }
 
+variable "model" {
+  description = "Reference to an existing model resource or data source for the model to deploy to."
+  type        = string
+}
+
 variable "units" {
   type        = number
   description = "Number of units to deploy with this name and configuration"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.21.1"
+      version = ">= 1.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR updates the Terraform integration for the temporal-admin-k8s-operator to use the new Juju provider v1.0.0, replaces the deprecated model attribute with model_uuid, and removes the need for specifying a model or UUID in the module inputs.

The model UUID is now resolved using the provider’s juju_model data source, ensuring that Terraform always deploys into the correct Juju model without requiring manual configuration or Justfile-injected values.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

## Key-Changes:
- Replace model attribute with `model_uuid`. 
-  New required field is `model_uuid = data.juju_model.terraform.uuid` 
- Introduce a `juju_model` data source to resolve model_uuid dynamically.
- Remove obsolete `model` variable declaration from `variables.tf`
- Upgrade provider version to v1.0.0
- `test/test.tfvars` no longer needs to declare `model = "terraform"`
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
just validate
just fmt
just lint
just test

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
