### PR TITLE
[WF-274] Skip TiCS workflow on fork PRs

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     tics:
+        if: github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name
         name: TiCs
         uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
         with: 

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -42,14 +42,14 @@ def database_connection_data():
         "db": {
             "dbname": "temporal-k8s_db",
             "host": "myhost",
-            "password": "inner-light",
+            "password": "inner-light",  # nosec B105
             "port": "4247",
             "user": "jean-luc@db",
         },
         "visibility": {
             "dbname": "temporal-k8s_visibility",
             "host": "myhost",
-            "password": "inner-light",
+            "password": "inner-light",  # nosec B105
             "port": "4247",
             "user": "jean-luc@visibility",
         },


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Skips the Tiobe TiCS Analysis workflow on PRs from forks so it doesn’t fail as fork PRs can’t use repo secrets.

# Changes
- Add `if` condition on the `tics` job: run only when `event_name != 'pull_request'` or when the PR head repo equals the workflow repo.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #124 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
