### PR TITLE
Retry admin schema setup when relation data or DB isn’t ready yet

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ import json
 import logging
 
 from ops import main, pebble
-from ops.charm import CharmBase
+from ops.charm import ActionEvent, CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from state import State
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 WORKLOAD_VERSION = "1.23.1"
 REQUIRED_DATABASE_CONNECTION_FIELDS = ("host", "port", "dbname", "user", "password")
 TRANSIENT_SCHEMA_SETUP_STATUS = "database temporarily unavailable; retrying schema setup"
+WAITING_DB_RELATION_INFO = "admin:temporal relation: waiting for database connection info"
 
 
 def log_event_handler(method):
@@ -120,7 +121,8 @@ class TemporalAdminK8SCharm(CharmBase):
         database_connections = event.relation.data[event.app].get("database_connections")
         if not database_connections:
             self._state.database_connections = None
-            self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
+            self.unit.status = WaitingStatus(WAITING_DB_RELATION_INFO)
+            event.defer()
             return
 
         try:
@@ -134,6 +136,7 @@ class TemporalAdminK8SCharm(CharmBase):
             self.unit.status = WaitingStatus(
                 f"admin:temporal relation: incomplete database connections data ({missing_fields})"
             )
+            event.defer()
             return
 
         self._state.database_connections = loaded_connections
@@ -203,7 +206,9 @@ class TemporalAdminK8SCharm(CharmBase):
             return False
 
         if not self._state.database_connections:
-            self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
+            self.unit.status = WaitingStatus(WAITING_DB_RELATION_INFO)
+            if not isinstance(event, ActionEvent):
+                event.defer()
             return False
 
         missing_fields = self._find_missing_database_connection_fields(self._state.database_connections)
@@ -211,6 +216,8 @@ class TemporalAdminK8SCharm(CharmBase):
             self.unit.status = WaitingStatus(
                 f"admin:temporal relation: incomplete database connections data ({missing_fields})"
             )
+            if not isinstance(event, ActionEvent):
+                event.defer()
             return False
 
         return True

--- a/src/charm.py
+++ b/src/charm.py
@@ -18,6 +18,7 @@ from state import State
 
 logger = logging.getLogger(__name__)
 WORKLOAD_VERSION = "1.23.1"
+REQUIRED_DATABASE_CONNECTION_FIELDS = ("host", "port", "dbname", "user", "password")
 
 
 def log_event_handler(method):
@@ -116,7 +117,29 @@ class TemporalAdminK8SCharm(CharmBase):
 
         self.unit.status = WaitingStatus(f"handling {event.relation.name} change")
         database_connections = event.relation.data[event.app].get("database_connections")
-        self._state.database_connections = json.loads(database_connections) if database_connections else None
+        if not database_connections:
+            self._state.database_connections = None
+            self.unit.status = BlockedStatus(
+                "admin:temporal relation: database connections info not available"
+            )
+            return
+
+        try:
+            loaded_connections = json.loads(database_connections)
+        except json.JSONDecodeError:
+            self.unit.status = BlockedStatus(
+                "admin:temporal relation: invalid database connections data"
+            )
+            return
+
+        missing_fields = self._find_missing_database_connection_fields(loaded_connections)
+        if missing_fields:
+            self.unit.status = WaitingStatus(
+                f"admin:temporal relation: incomplete database connections data ({missing_fields})"
+            )
+            return
+
+        self._state.database_connections = loaded_connections
         self._setup_db_schemas(event)
 
     @log_event_handler
@@ -194,6 +217,13 @@ class TemporalAdminK8SCharm(CharmBase):
             self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
             return
 
+        missing_fields = self._find_missing_database_connection_fields(self._state.database_connections)
+        if missing_fields:
+            self.unit.status = WaitingStatus(
+                f"admin:temporal relation: incomplete database connections data ({missing_fields})"
+            )
+            return
+
         schema_dirs = {
             "db": "/etc/temporal/schema/postgresql/v12/temporal/versioned",
             "visibility": "/etc/temporal/schema/postgresql/v12/visibility/versioned",
@@ -268,6 +298,23 @@ class TemporalAdminK8SCharm(CharmBase):
         self._state.is_initial_schema_ready = True
         self.unit.set_workload_version(WORKLOAD_VERSION)
         self.unit.status = ActiveStatus()
+
+    def _find_missing_database_connection_fields(self, database_connections):
+        """Return missing required relation fields, if any."""
+        if not isinstance(database_connections, dict):
+            return "database_connections must be a mapping"
+
+        for connection_name in ("db", "visibility"):
+            connection = database_connections.get(connection_name)
+            if not isinstance(connection, dict):
+                return f"{connection_name}: missing connection details"
+
+            missing = [field for field in REQUIRED_DATABASE_CONNECTION_FIELDS if not connection.get(field)]
+            if missing:
+                missing_list = ", ".join(missing)
+                return f"{connection_name}: missing {missing_list}"
+
+        return ""
 
 
 def execute(container, command, *args):

--- a/src/charm.py
+++ b/src/charm.py
@@ -120,17 +120,13 @@ class TemporalAdminK8SCharm(CharmBase):
         database_connections = event.relation.data[event.app].get("database_connections")
         if not database_connections:
             self._state.database_connections = None
-            self.unit.status = BlockedStatus(
-                "admin:temporal relation: database connections info not available"
-            )
+            self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
             return
 
         try:
             loaded_connections = json.loads(database_connections)
         except json.JSONDecodeError:
-            self.unit.status = BlockedStatus(
-                "admin:temporal relation: invalid database connections data"
-            )
+            self.unit.status = BlockedStatus("admin:temporal relation: invalid database connections data")
             return
 
         missing_fields = self._find_missing_database_connection_fields(loaded_connections)
@@ -192,6 +188,33 @@ class TemporalAdminK8SCharm(CharmBase):
         except Exception as err:
             event.fail(err)
 
+    def _ensure_schema_setup_prerequisites(self, event) -> bool:
+        """Return True when schema setup should run; otherwise set status/defer and return False."""
+        if not self.model.unit.is_leader():
+            return False
+
+        if not self._state.is_ready():
+            event.defer()
+            return False
+
+        container = self.unit.get_container(self.name)
+        if not container.can_connect():
+            event.defer()
+            return False
+
+        if not self._state.database_connections:
+            self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
+            return False
+
+        missing_fields = self._find_missing_database_connection_fields(self._state.database_connections)
+        if missing_fields:
+            self.unit.status = WaitingStatus(
+                f"admin:temporal relation: incomplete database connections data ({missing_fields})"
+            )
+            return False
+
+        return True
+
     # flake8: noqa: C901
     def _setup_db_schemas(self, event):
         """Initialize the db schemas if db connections info is available.
@@ -202,29 +225,10 @@ class TemporalAdminK8SCharm(CharmBase):
         Raises:
             Exception: if the schemas were not set up successfully.
         """
-        if not self.model.unit.is_leader():
-            return
-
-        if not self._state.is_ready():
-            event.defer()
+        if not self._ensure_schema_setup_prerequisites(event):
             return
 
         container = self.unit.get_container(self.name)
-        if not container.can_connect():
-            event.defer()
-            return
-
-        if not self._state.database_connections:
-            self.unit.status = BlockedStatus("admin:temporal relation: database connections info not available")
-            return
-
-        missing_fields = self._find_missing_database_connection_fields(self._state.database_connections)
-        if missing_fields:
-            self.unit.status = WaitingStatus(
-                f"admin:temporal relation: incomplete database connections data ({missing_fields})"
-            )
-            return
-
         schema_dirs = {
             "db": "/etc/temporal/schema/postgresql/v12/temporal/versioned",
             "visibility": "/etc/temporal/schema/postgresql/v12/visibility/versioned",
@@ -320,6 +324,7 @@ class TemporalAdminK8SCharm(CharmBase):
                 return f"{connection_name}: missing {missing_list}"
 
         return ""
+
 
 def execute(container, command, *args):
     """Execute the given command in the given container.

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ import functools
 import json
 import logging
 
-from ops import main
+from ops import main, pebble
 from ops.charm import CharmBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
@@ -19,6 +19,7 @@ from state import State
 logger = logging.getLogger(__name__)
 WORKLOAD_VERSION = "1.23.1"
 REQUIRED_DATABASE_CONNECTION_FIELDS = ("host", "port", "dbname", "user", "password")
+TRANSIENT_SCHEMA_SETUP_STATUS = "database temporarily unavailable; retrying schema setup"
 
 
 def log_event_handler(method):
@@ -281,6 +282,10 @@ class TemporalAdminK8SCharm(CharmBase):
                 execute(container, "temporal-sql-tool", *command_args)
             except Exception as e:
                 logger.error(f"Error setting up schema: {e}")
+                if isinstance(e, (pebble.ExecError, pebble.ChangeError)) and hasattr(event, "defer"):
+                    self.unit.status = WaitingStatus(TRANSIENT_SCHEMA_SETUP_STATUS)
+                    event.defer()
+                    return
                 raise Exception from e
 
         admin_relations = self.model.relations["admin"]
@@ -315,7 +320,6 @@ class TemporalAdminK8SCharm(CharmBase):
                 return f"{connection_name}: missing {missing_list}"
 
         return ""
-
 
 def execute(container, command, *args):
     """Execute the given command in the given container.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -132,15 +132,12 @@ class TestDeployment:
         await run_cli_action(ops_test, namespace="integrations")
 
     async def test_remove_server(self, ops_test: OpsTest):
-        """Admin charm goes to blocked state once relation with the server charm is removed."""
+        """Admin charm enters waiting once the server app is removed (no database connection info)."""
         await ops_test.model.applications[SERVER_APP_NAME].destroy()
         await ops_test.model.block_until(lambda: SERVER_APP_NAME not in ops_test.model.applications)
 
-        await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="blocked",
-            raise_on_blocked=False,
-            timeout=300,
-        )
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], raise_on_blocked=False, timeout=300)
 
-        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "blocked"
+        unit = ops_test.model.applications[APP_NAME].units[0]
+        assert unit.workload_status == "waiting"
+        assert "database connection info" in (unit.workload_status_message or "")

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -39,8 +39,9 @@ async def deploy(ops_test: OpsTest):
 
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
-            apps=[SERVER_APP_NAME, APP_NAME], status="blocked", raise_on_blocked=False, timeout=600
+            apps=[SERVER_APP_NAME], status="blocked", raise_on_blocked=False, timeout=600
         )
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], raise_on_blocked=False, timeout=600)
         await ops_test.model.wait_for_idle(
             apps=["postgresql-k8s"], status="active", raise_on_blocked=False, timeout=600
         )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -132,7 +132,7 @@ class TestDeployment:
         await run_cli_action(ops_test, namespace="integrations")
 
     async def test_remove_server(self, ops_test: OpsTest):
-        """Admin charm enters waiting once the server app is removed (no database connection info)."""
+        """After server removal, admin waits: no database connection info on the relation."""
         await ops_test.model.applications[SERVER_APP_NAME].destroy()
         await ops_test.model.block_until(lambda: SERVER_APP_NAME not in ops_test.model.applications)
 

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -19,6 +19,7 @@ def pytest_configure(config):
     """
     config.addinivalue_line("markers", "admin_relation_skipped")
     config.addinivalue_line("markers", "admin_relation_uninitialized")
+    config.addinivalue_line("markers", "admin_relation_incomplete")
 
 
 @pytest.fixture
@@ -59,6 +60,17 @@ def database_connection_data():
 @pytest.fixture(scope="function")
 def peer_relation(request, database_connection_data):
     state_data = {}
+    if request.node.get_closest_marker("admin_relation_incomplete"):
+        incomplete_data = {
+            **database_connection_data,
+            "db": {
+                key: value
+                for key, value in database_connection_data["db"].items()
+                if key != "password"
+            },
+        }
+        state_data["database_connections"] = json.dumps(incomplete_data)
+        return ops.testing.PeerRelation("peer", local_app_data=state_data)
 
     if not request.node.get_closest_marker("admin_relation_skipped") and not request.node.get_closest_marker(
         "admin_relation_uninitialized"
@@ -70,6 +82,18 @@ def peer_relation(request, database_connection_data):
 
 @pytest.fixture(scope="function")
 def admin_relation(request, database_connection_data):
+    if request.node.get_closest_marker("admin_relation_incomplete"):
+        incomplete_data = {
+            **database_connection_data,
+            "db": {
+                key: value
+                for key, value in database_connection_data["db"].items()
+                if key != "password"
+            },
+        }
+        remote_app_data = {"database_connections": json.dumps(incomplete_data)}
+        return ops.testing.Relation("admin", remote_app_data=remote_app_data)
+
     remote_app_data = (
         {
             "database_connections": json.dumps(database_connection_data),

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -63,11 +63,7 @@ def peer_relation(request, database_connection_data):
     if request.node.get_closest_marker("admin_relation_incomplete"):
         incomplete_data = {
             **database_connection_data,
-            "db": {
-                key: value
-                for key, value in database_connection_data["db"].items()
-                if key != "password"
-            },
+            "db": {key: value for key, value in database_connection_data["db"].items() if key != "password"},
         }
         state_data["database_connections"] = json.dumps(incomplete_data)
         return ops.testing.PeerRelation("peer", local_app_data=state_data)
@@ -85,11 +81,7 @@ def admin_relation(request, database_connection_data):
     if request.node.get_closest_marker("admin_relation_incomplete"):
         incomplete_data = {
             **database_connection_data,
-            "db": {
-                key: value
-                for key, value in database_connection_data["db"].items()
-                if key != "password"
-            },
+            "db": {key: value for key, value in database_connection_data["db"].items() if key != "password"},
         }
         remote_app_data = {"database_connections": json.dumps(incomplete_data)}
         return ops.testing.Relation("admin", remote_app_data=remote_app_data)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -65,3 +65,18 @@ def test_ready(context, state, temporal_admin_container):
         assert state_out.get_container("temporal-admin").plan.to_dict() == {}
 
         assert execute.call_count == 4
+
+
+def test_transient_schema_setup_error_waits_for_retry(context, state, temporal_admin_container):
+    with unittest.mock.patch("charm.execute") as execute:
+        execute.side_effect = ops.pebble.ExecError(
+            command=["temporal-sql-tool", "setup-schema"],
+            exit_code=1,
+            stdout="",
+            stderr="Unable to connect to SQL database",
+        )
+        state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)
+
+        assert state_out.unit_status == ops.WaitingStatus(
+            "database temporarily unavailable; retrying schema setup"
+        )

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -77,6 +77,4 @@ def test_transient_schema_setup_error_waits_for_retry(context, state, temporal_a
         )
         state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)
 
-        assert state_out.unit_status == ops.WaitingStatus(
-            "database temporarily unavailable; retrying schema setup"
-        )
+        assert state_out.unit_status == ops.WaitingStatus("database temporarily unavailable; retrying schema setup")

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -48,6 +48,15 @@ def test_missing_admin_relation_data(context, state, temporal_admin_container):
     )
 
 
+@pytest.mark.admin_relation_incomplete
+def test_incomplete_admin_relation_data(context, state, temporal_admin_container):
+    state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)
+
+    assert state_out.unit_status == ops.WaitingStatus(
+        "admin:temporal relation: incomplete database connections data (db: missing password)"
+    )
+
+
 def test_ready(context, state, temporal_admin_container):
     with unittest.mock.patch("charm.execute") as execute:
         state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -8,6 +8,8 @@ import ops
 import ops.testing
 import pytest
 
+from charm import WAITING_DB_RELATION_INFO
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,18 +36,14 @@ def state(temporal_admin_container, all_required_relations):
 def test_missing_admin_relation(context, state, temporal_admin_container):
     state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)
 
-    assert state_out.unit_status == ops.BlockedStatus(
-        "admin:temporal relation: database connections info not available"
-    )
+    assert state_out.unit_status == ops.WaitingStatus(WAITING_DB_RELATION_INFO)
 
 
 @pytest.mark.admin_relation_uninitialized
 def test_missing_admin_relation_data(context, state, temporal_admin_container):
     state_out = context.run(context.on.pebble_ready(temporal_admin_container), state)
 
-    assert state_out.unit_status == ops.BlockedStatus(
-        "admin:temporal relation: database connections info not available"
-    )
+    assert state_out.unit_status == ops.WaitingStatus(WAITING_DB_RELATION_INFO)
 
 
 @pytest.mark.admin_relation_incomplete


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR hardens `temporal-admin` when the `admin:temporal` relation is not fully populated yet, and when schema commands hit transient infrastructure pressure (DB pool saturation, Pebble exec timeouts).

### Problem

`admin-relation-changed` could run with missing or partial `database_connections`, or the workload could attempt `temporal-sql-tool` while Postgres/PgBouncer was temporarily unable to accept more connections.
That led to hook failures (`hook failed: admin-relation-changed`) and unstable status, especially with multiple admin relations (split Temporal topology) and bursts of relation events after deploy or charm refresh.

- Under load, logs showed `pq: remaining connection slots…`, `too many clients`, and `Pebble ExecError / ChangeError` (e.g. command timeout / “cannot perform the following tasks”) from `temporal-sql-tool`.
- Relation readiness check alone is insufficient: credentials can be present while the DB path is still saturated for short periods.

### Changes
- Validate `database_connections` before running schema setup; use `WaitingStatus` when data is incomplete so the next relation update can retry without treating it as a hard operator error.
- On `pebble.ExecError` and `pebble.ChangeError` during schema setup, set `WaitingStatus`, `event.defer()`, and return so transient Pebble/DB pressure does not fail the hook the same way as a logic bug.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Related to PR: https://github.com/canonical/charmed-temporal-solutions/pull/20
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->
- `temporal-admin` does not relate to Postgres directly; DB details come from `temporal-k8s` on each admin relation. With four Temporal apps, there are four relations and more `admin-relation-changed` traffic. this PR reduces hook hard-failures under that pattern.

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
