### PR TITLE
[WF-343] Add temporal-host-info to Terraform requires output

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,9 @@ output "provides" {
     admin = "admin"
   }
 }
+
+output "requires" {
+  value = {
+    temporal_host_info = "temporal-host-info"
+  }
+}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Ensure terraform/outputs.tf exposes temporal_host_info = "temporal-host-info" under output "requires" so bundles can reference module.<...>.requires.temporal_host_info for temporal-host-info integrations with Temporal frontend.


<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
