### PR TITLE
chore(chamcraft, ci): bump base 24.04 -> 26.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,5 +21,5 @@ jobs:
     with:
       release-channel: "1.23/edge"
       charm-path: "."
-      charmcraft-channel: "3.x/candidate"
+      charmcraft-channel: "4.x/candidate"
       runners: '["ubuntu-latest"]'

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -7,7 +7,7 @@
 type: "charm"
 
 platforms:
-  ubuntu@24.04:amd64:
+  ubuntu@26.04:amd64:
 
 parts:
   charm:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Bump the version of the base to match latest Ubuntu LTS.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

Do not merge before #51 

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
