### PR TITLE
chore(tests): bump version to deploy/refresh from

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,8 +10,12 @@ import pytest
 import yaml
 
 POSTGRESQL_CHANNEL = "14/stable"
-TEMPORAL_CHANNEL = "1.23/edge"
-TEMPORAL_LEGACY_CHANNEL = "latest/stable"
+
+# Temporal charm channels. Bump these when the charms migrate to a new track
+# (e.g. 1.23 -> 1.31).
+TEMPORAL_CHANNEL = "1.23/edge"  # server dependency and the default admin deploy
+TEMPORAL_ADMIN_LATEST_RELEASE_CHANNEL = "1.23/stable"  # published admin release the refresh test upgrades from
+
 TEMPORAL_SERVER_APP_NAME = "temporal-k8s"
 
 METADATA = yaml.safe_load(pathlib.Path("./metadata.yaml").read_text())
@@ -38,7 +42,7 @@ def deploy_temporal_stack(
     temporal_channel: str = TEMPORAL_CHANNEL,
     temporal_admin_channel: str = TEMPORAL_CHANNEL,
 ):
-    """Deploy temporal-admin-k8s from the latest track.
+    """Deploy the temporal stack.
 
     Args:
         juju: Juju object (jubilant)
@@ -87,8 +91,11 @@ def deploy_temporal_stack(
 
 @pytest.fixture(scope="module")
 def admin_tools_latest_track(juju: jubilant.Juju):
-    """Deploy temporal-admin-k8s from the latest track."""
-    deploy_temporal_stack(juju, temporal_admin_channel=TEMPORAL_LEGACY_CHANNEL)
+    """Deploy the temporal stack with temporal-admin from the latest supported release.
+
+    The refresh test then upgrades this deployment to the newer, locally built charm.
+    """
+    deploy_temporal_stack(juju, temporal_admin_channel=TEMPORAL_ADMIN_LATEST_RELEASE_CHANNEL)
 
     yield "temporal-admin-k8s"
 

--- a/tests/integration/test_refresh.py
+++ b/tests/integration/test_refresh.py
@@ -1,14 +1,14 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Test to ensure successful refreshes from latest track to the 1.23 track."""
+"""Test to ensure successful refreshes from the latest supported release to the newer charm."""
 
 import jubilant
 from conftest import TEMPORAL_SERVER_APP_NAME
 
 
 def test_refresh_from_latest_to_1_23(juju: jubilant.Juju, admin_tools_latest_track, charm_path, charm_resources):
-    """Test to refresh from latest track to the 1.23 track."""
+    """Refresh from the latest supported temporal-admin-k8s release to the local build."""
     juju.refresh(
         admin_tools_latest_track,
         path=charm_path,


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Due to the recent changes in the Temporal workload version, the refresh integration test must verify the upgrade path from a previous version to the newer one; therefore, this commit bumps the version from which we are deploying and refreshing from (replace latest/stable with 1.23/stable).

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

There are references to 1.23 channel, we need to change those in a separate PR once all the Temporal charms are released to 1.31.

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
